### PR TITLE
feat: implement configurable default actions for monetary and non-monetary conversion results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.3.0-dev
 
+- [FEAT] add a configurable default action for rate-backed currency results, with Command-Return performing the alternate website or clipboard action
 - [FEAT] migrate the Alfred workflow runtime from Dart to Rust while preserving currency conversion, caching, modifiers, updater behaviour, and existing workflow preferences
 - [FEAT] replace `units_converter` with Numbat, adding native expression support while retaining historical unit aliases, coefficients, formatting, and friendly conversion syntax
 - [FIX] preserve precise ECB currency calculations, offline stale-cache fallback, legacy Dart-cache imports, and TARGET publication-day handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.3.0-dev
 
-- [FEAT] add a configurable default action for rate-backed currency results, with Command-Return performing the alternate website or clipboard action
+- [FEAT] add separate configurable default actions for monetary and non-monetary results, with Command-Return performing the alternate website or clipboard action
 - [FEAT] migrate the Alfred workflow runtime from Dart to Rust while preserving currency conversion, caching, modifiers, updater behaviour, and existing workflow preferences
 - [FEAT] replace `units_converter` with Numbat, adding native expression support while retaining historical unit aliases, coefficients, formatting, and friendly conversion syntax
 - [FIX] preserve precise ECB currency calculations, offline stale-cache fallback, legacy Dart-cache imports, and TARGET publication-day handling

--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ Heavily inspired by [deanishe/alfred-convert](https://github.com/deanishe/alfred
 ## Usage
 
 - `conv <quantity> <from unit> <to unit>` - Perform a conversion
-    - For monetary conversions, <kbd>return</kbd> (↵) performs the configured Default action: open the currency-pair chart on [Xe.com](http://www.xe.com) or copy the converted value.
+    - For monetary conversions, <kbd>return</kbd> (↵) performs the configured Default monetary action: open the currency-pair chart on [Xe.com](http://www.xe.com) or copy the converted value.
       - <kbd>cmd+return</kbd> (⌘↵) performs the alternate action.
       - <kbd>option+return</kbd> (⌥↵) shows the inverse conversion and copies its value when Copy to clipboard is the default.
       - Quick Look (`⌘Y`) always opens the Xe chart.
-    - When performing a physical unit conversion pressing `⌘Y` or <kbd>return</kbd> (↵) will open up detailed the conversion
-      explanation on [WolframAlpha.com](https://www.wolframalpha.com).
+    - For physical unit conversions and other Numbat evaluations, <kbd>return</kbd> (↵) performs the configured Default non-monetary action: open the result on [WolframAlpha.com](https://www.wolframalpha.com) or copy the converted value.
+      - <kbd>cmd+return</kbd> (⌘↵) performs the alternate action.
+      - Quick Look (`⌘Y`) always opens the WolframAlpha result.
 - `conv money` - View a list of all the supported currencies
-    - Rate-backed rows use the same configured Default action and <kbd>cmd+return</kbd> (⌘↵) alternate action.
+    - Rate-backed rows use the same configured Default monetary action and <kbd>cmd+return</kbd> (⌘↵) alternate action.
       - <kbd>option+return</kbd> (⌥↵) shows the inverse rate and copies it when Copy to clipboard is the default.
       - Quick Look (`⌘Y`) always opens the Xe chart.
 - `conv units` - View a list of all the supported physical units
@@ -42,9 +43,9 @@ In order to set a default currency, you can set it in the Workflow Configuration
 Valid values are the [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency codes: AUD, BRL, CAD, CHF, CNY, CZK, 
 DKK, EUR, GBP, HKD, HUF, IDR, ILS, INR, ISK, JPY, KRW, MXN, MYR, NOK, NZD, PHP, PLN, RON, RUB, SEK, SGD, THB, TRY, USD, ZAR.
 
-### Default action
+### Default actions
 
-The Workflow Configuration also lets you choose what <kbd>return</kbd> does for currency conversions and rate-backed currency rows. `Open website` remains the default; choose `Copy to clipboard` to copy the converted value instead. <kbd>cmd+return</kbd> always performs the alternate action.
+The Workflow Configuration provides separate Default monetary action and Default non-monetary action preferences. `Open website` remains the default for both; choose `Copy to clipboard` to copy only the converted value instead. <kbd>cmd+return</kbd> always performs the alternate action.
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -20,15 +20,16 @@ Heavily inspired by [deanishe/alfred-convert](https://github.com/deanishe/alfred
 ## Usage
 
 - `conv <quantity> <from unit> <to unit>` - Perform a conversion
-    - When performing a monetary conversion pressing `⌘Y` or <kbd>return</kbd> (↵) will open the currency-pair chart on [Xe.com](http://www.xe.com).
-      - When pressing <kbd>option+return</kbd> (⌥↵) you will get the inverse currency conversion, i.e. `12 USD to EUR` becomes `12 EUR to USD`.
-      - When pressing <kbd>cmd+return</kbd> (⌘↵) you will copy the converted value to your clipboard.
+    - For monetary conversions, <kbd>return</kbd> (↵) performs the configured Default action: open the currency-pair chart on [Xe.com](http://www.xe.com) or copy the converted value.
+      - <kbd>cmd+return</kbd> (⌘↵) performs the alternate action.
+      - <kbd>option+return</kbd> (⌥↵) shows the inverse conversion and copies its value when Copy to clipboard is the default.
+      - Quick Look (`⌘Y`) always opens the Xe chart.
     - When performing a physical unit conversion pressing `⌘Y` or <kbd>return</kbd> (↵) will open up detailed the conversion
       explanation on [WolframAlpha.com](https://www.wolframalpha.com).
 - `conv money` - View a list of all the supported currencies
-    - When pressing `⌘Y` or <kbd>return</kbd> (↵) on a certain currency you will be directed to the chart with the home currency on [Xe.com](http://www.xe.com).
-      - When pressing <kbd>option+return</kbd> (⌥↵) you will get the inverse currency conversion, i.e. `1 AUD = 0.558 GBP` becomes `1 GBP = 1.792 AUD`.
-      - When pressing <kbd>cmd+return</kbd> (⌘↵) you will copy the equivalent in the home currency to your clipboard.
+    - Rate-backed rows use the same configured Default action and <kbd>cmd+return</kbd> (⌘↵) alternate action.
+      - <kbd>option+return</kbd> (⌥↵) shows the inverse rate and copies it when Copy to clipboard is the default.
+      - Quick Look (`⌘Y`) always opens the Xe chart.
 - `conv units` - View a list of all the supported physical units
     - When selecting a certain unit and pressing <kbd>return</kbd> (↵) that unit's symbol will get copied to the clipboard.
 
@@ -40,6 +41,10 @@ In order to set a default currency, you can set it in the Workflow Configuration
 
 Valid values are the [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency codes: AUD, BRL, CAD, CHF, CNY, CZK, 
 DKK, EUR, GBP, HKD, HUF, IDR, ILS, INR, ISK, JPY, KRW, MXN, MYR, NOK, NZD, PHP, PLN, RON, RUB, SEK, SGD, THB, TRY, USD, ZAR.
+
+### Default action
+
+The Workflow Configuration also lets you choose what <kbd>return</kbd> does for currency conversions and rate-backed currency rows. `Open website` remains the default; choose `Copy to clipboard` to copy the converted value instead. <kbd>cmd+return</kbd> always performs the alternate action.
 
 ### Notes
 

--- a/info.plist
+++ b/info.plist
@@ -330,14 +330,15 @@ Heavily inspired by [deanishe/alfred-convert](https://github.com/deanishe/alfred
 ## Usage
 
 - `conv &lt;quantity&gt; &lt;from unit&gt; &lt;to unit&gt;` - Perform a conversion
-    - For monetary conversions, &lt;kbd&gt;return&lt;/kbd&gt; (↵) performs the configured Default action: open the currency-pair chart on [Xe.com](http://www.xe.com) or copy the converted value.
+    - For monetary conversions, &lt;kbd&gt;return&lt;/kbd&gt; (↵) performs the configured Default monetary action: open the currency-pair chart on [Xe.com](http://www.xe.com) or copy the converted value.
       - &lt;kbd&gt;cmd+return&lt;/kbd&gt; (⌘↵) performs the alternate action.
       - &lt;kbd&gt;option+return&lt;/kbd&gt; (⌥↵) shows the inverse conversion and copies its value when Copy to clipboard is the default.
       - Quick Look (`⌘Y`) always opens the Xe chart.
-    - When performing a physical unit conversion pressing `⌘Y` or &lt;kbd&gt;return&lt;/kbd&gt; (↵) will open up detailed the conversion
-      explanation on [WolframAlpha.com](https://www.wolframalpha.com).
+    - For physical unit conversions and other Numbat evaluations, &lt;kbd&gt;return&lt;/kbd&gt; (↵) performs the configured Default non-monetary action: open the result on [WolframAlpha.com](https://www.wolframalpha.com) or copy the converted value.
+      - &lt;kbd&gt;cmd+return&lt;/kbd&gt; (⌘↵) performs the alternate action.
+      - Quick Look (`⌘Y`) always opens the WolframAlpha result.
 - `conv money` - View a list of all the supported currencies
-    - Rate-backed rows use the same configured Default action and &lt;kbd&gt;cmd+return&lt;/kbd&gt; (⌘↵) alternate action.
+    - Rate-backed rows use the same configured Default monetary action and &lt;kbd&gt;cmd+return&lt;/kbd&gt; (⌘↵) alternate action.
       - &lt;kbd&gt;option+return&lt;/kbd&gt; (⌥↵) shows the inverse rate and copies it when Copy to clipboard is the default.
       - Quick Look (`⌘Y`) always opens the Xe chart.
 - `conv units` - View a list of all the supported physical units
@@ -551,11 +552,37 @@ Heavily inspired by [deanishe/alfred-convert](https://github.com/deanishe/alfred
 			<key>description</key>
 			<string>Choose what Return does for currency results.</string>
 			<key>label</key>
-			<string>Default action</string>
+			<string>Default monetary action</string>
 			<key>type</key>
 			<string>popupbutton</string>
 			<key>variable</key>
-			<string>default_action</string>
+			<string>default_monetary_action</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>open_website</string>
+				<key>pairs</key>
+				<array>
+					<array>
+						<string>Open website</string>
+						<string>open_website</string>
+					</array>
+					<array>
+						<string>Copy to clipboard</string>
+						<string>copy_to_clipboard</string>
+					</array>
+				</array>
+			</dict>
+			<key>description</key>
+			<string>Choose what Return does for non-monetary results.</string>
+			<key>label</key>
+			<string>Default non-monetary action</string>
+			<key>type</key>
+			<string>popupbutton</string>
+			<key>variable</key>
+			<string>default_non_monetary_action</string>
 		</dict>
 	</array>
 	<key>version</key>

--- a/info.plist
+++ b/info.plist
@@ -20,11 +20,11 @@
 			</dict>
 			<dict>
 				<key>destinationuid</key>
-				<string>572C1CAB-814A-4C59-8D8C-04C69F788090</string>
+				<string>DF31843F-F908-4B26-BA46-A24A1C902306</string>
 				<key>modifiers</key>
 				<integer>1048576</integer>
 				<key>modifiersubtext</key>
-				<string>Only copy to clipboard</string>
+				<string></string>
 				<key>vitoclose</key>
 				<false/>
 			</dict>
@@ -330,15 +330,16 @@ Heavily inspired by [deanishe/alfred-convert](https://github.com/deanishe/alfred
 ## Usage
 
 - `conv &lt;quantity&gt; &lt;from unit&gt; &lt;to unit&gt;` - Perform a conversion
-    - When performing a monetary conversion pressing `⌘Y` or &lt;kbd&gt;return&lt;/kbd&gt; (↵) will open the currency-pair chart on [Xe.com](http://www.xe.com).
-      - When pressing &lt;kbd&gt;option+return&lt;/kbd&gt; (⌥↵) you will get the inverse currency conversion, i.e. `12 USD to EUR` becomes `12 EUR to USD`.
-      - When pressing &lt;kbd&gt;cmd+return&lt;/kbd&gt; (⇧↵) you will copy the converted value to your clipboard.
+    - For monetary conversions, &lt;kbd&gt;return&lt;/kbd&gt; (↵) performs the configured Default action: open the currency-pair chart on [Xe.com](http://www.xe.com) or copy the converted value.
+      - &lt;kbd&gt;cmd+return&lt;/kbd&gt; (⌘↵) performs the alternate action.
+      - &lt;kbd&gt;option+return&lt;/kbd&gt; (⌥↵) shows the inverse conversion and copies its value when Copy to clipboard is the default.
+      - Quick Look (`⌘Y`) always opens the Xe chart.
     - When performing a physical unit conversion pressing `⌘Y` or &lt;kbd&gt;return&lt;/kbd&gt; (↵) will open up detailed the conversion
       explanation on [WolframAlpha.com](https://www.wolframalpha.com).
 - `conv money` - View a list of all the supported currencies
-    - When pressing `⌘Y` or &lt;kbd&gt;return&lt;/kbd&gt; (↵) on a certain currency you will be directed to the chart with the home currency on [Xe.com](http://www.xe.com).
-      - When pressing &lt;kbd&gt;option+return&lt;/kbd&gt; (⌥↵) you will get the inverse currency conversion, i.e. `1 AUD = 0.558 GBP` becomes `1 GBP = 1.792 AUD`.
-      - When pressing &lt;kbd&gt;cmd+return&lt;/kbd&gt; (⇧↵) you will copy the equivalent in the home currency to your clipboard.
+    - Rate-backed rows use the same configured Default action and &lt;kbd&gt;cmd+return&lt;/kbd&gt; (⌘↵) alternate action.
+      - &lt;kbd&gt;option+return&lt;/kbd&gt; (⌥↵) shows the inverse rate and copies it when Copy to clipboard is the default.
+      - Quick Look (`⌘Y`) always opens the Xe chart.
 - `conv units` - View a list of all the supported physical units
     - When selecting a certain unit and pressing &lt;kbd&gt;return&lt;/kbd&gt; (↵) that unit's symbol will get copied to the clipboard.</string>
 	<key>uidata</key>
@@ -529,6 +530,32 @@ Heavily inspired by [deanishe/alfred-convert](https://github.com/deanishe/alfred
 			<string>popupbutton</string>
 			<key>variable</key>
 			<string>default_currency</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>open_website</string>
+				<key>pairs</key>
+				<array>
+					<array>
+						<string>Open website</string>
+						<string>open_website</string>
+					</array>
+					<array>
+						<string>Copy to clipboard</string>
+						<string>copy_to_clipboard</string>
+					</array>
+				</array>
+			</dict>
+			<key>description</key>
+			<string>Choose what Return does for currency results.</string>
+			<key>label</key>
+			<string>Default action</string>
+			<key>type</key>
+			<string>popupbutton</string>
+			<key>variable</key>
+			<string>default_action</string>
 		</dict>
 	</array>
 	<key>version</key>

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,6 +23,27 @@ pub struct PendingItem {
     emoji: Option<String>,
 }
 
+/// Default Return action for rate-backed currency results.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum CurrencyDefaultAction {
+    /// Open the currency-pair chart on Xe.com.
+    #[default]
+    OpenWebsite,
+    /// Copy the converted value to the clipboard.
+    CopyToClipboard,
+}
+
+impl CurrencyDefaultAction {
+    /// Parses the stored Alfred preference, falling back to the website action.
+    #[must_use]
+    pub fn from_preference(value: Option<&str>) -> Self {
+        match value {
+            Some("copy_to_clipboard") => Self::CopyToClipboard,
+            _ => Self::OpenWebsite,
+        }
+    }
+}
+
 impl PendingItem {
     fn new(item: Item, emoji: Option<&str>) -> Self {
         Self {
@@ -67,6 +88,7 @@ pub fn invalid_item(message: Option<&str>) -> Item {
 pub fn conversion_item(
     query: &str,
     home: Currency,
+    default_action: CurrencyDefaultAction,
     rates: Option<&ExchangeRates>,
     unit_engine: &mut Option<UnitEngine>,
 ) -> Result<PendingItem> {
@@ -75,7 +97,7 @@ pub fn conversion_item(
         if parse_decimal(parts[0]).is_none() {
             return Ok(PendingItem::new(invalid_item(None), None));
         }
-        return currency_conversion_item(&parts, from, home, rates);
+        return currency_conversion_item(&parts, from, home, default_action, rates);
     }
     if parts
         .iter()
@@ -128,6 +150,7 @@ fn currency_conversion_item(
     parts: &[&str],
     from: Currency,
     home: Currency,
+    default_action: CurrencyDefaultAction,
     rates: Option<&ExchangeRates>,
 ) -> Result<PendingItem> {
     let to_code = match parts {
@@ -159,6 +182,30 @@ fn currency_conversion_item(
         .checked_mul(inverted_rate)
         .ok_or_else(|| anyhow!("inverse currency conversion overflowed"))?;
     let url = xe_url(from, to)?;
+    let actions = currency_actions(
+        default_action,
+        url.as_str(),
+        format!("{} {}", format_decimal(converted), to.code()),
+        format!("{} {}", format_decimal(inverted), from.code()),
+        format!(
+            "Copy {} {} {} to clipboard",
+            format_decimal(converted),
+            to.code(),
+            to.flag()
+        ),
+    );
+    let mut inverse_modifier = Modifier::new().with_subtitle(format!(
+        "{} {} {} ≃ {} {} {}",
+        format_decimal(amount),
+        to.code(),
+        to.flag(),
+        format_decimal(inverted),
+        from.code(),
+        from.flag()
+    ));
+    if let Some(argument) = actions.inverse_arg {
+        inverse_modifier = inverse_modifier.with_arg(argument);
+    }
     let item = Item::with_arg(
         format!(
             "{} {} {} ≃ {} {} {}",
@@ -169,34 +216,13 @@ fn currency_conversion_item(
             to.code(),
             to.flag()
         ),
-        url.as_str(),
+        actions.default_arg,
     )
     .set_subtitle(exchange_rate_subtitle(rates.date))
     .set_quick_look_url(url.as_str())
     .set_valid(true)
-    .try_set_modifier(
-        [ModifierKey::Alt],
-        Modifier::new().with_subtitle(format!(
-            "{} {} {} ≃ {} {} {}",
-            format_decimal(amount),
-            to.code(),
-            to.flag(),
-            format_decimal(inverted),
-            from.code(),
-            from.flag()
-        )),
-    )?
-    .try_set_modifier(
-        [ModifierKey::Cmd],
-        Modifier::new()
-            .with_subtitle(format!(
-                "Copy {} {} {} to clipboard",
-                format_decimal(converted),
-                to.code(),
-                to.flag()
-            ))
-            .with_arg(format!("{} {}", format_decimal(converted), to.code())),
-    )?;
+    .try_set_modifier([ModifierKey::Alt], inverse_modifier)?
+    .try_set_modifier([ModifierKey::Cmd], actions.command_modifier)?;
     Ok(PendingItem::new(item, Some(to.flag())))
 }
 
@@ -204,17 +230,22 @@ fn currency_conversion_item(
 ///
 /// # Errors
 /// Returns an error if a URL or modifier cannot be built.
-pub fn currency_items(home: Currency, rates: Option<&ExchangeRates>) -> Result<Vec<PendingItem>> {
+pub fn currency_items(
+    home: Currency,
+    default_action: CurrencyDefaultAction,
+    rates: Option<&ExchangeRates>,
+) -> Result<Vec<PendingItem>> {
     CURRENCIES
         .iter()
         .copied()
-        .map(|currency| currency_catalog_item(currency, home, rates))
+        .map(|currency| currency_catalog_item(currency, home, default_action, rates))
         .collect()
 }
 
 fn currency_catalog_item(
     currency: Currency,
     home: Currency,
+    default_action: CurrencyDefaultAction,
     rates: Option<&ExchangeRates>,
 ) -> Result<PendingItem> {
     if currency != home
@@ -222,9 +253,30 @@ fn currency_catalog_item(
     {
         let inverse = divide_like_dart(Decimal::ONE, rate)?;
         let url = xe_url(currency, home)?;
+        let actions = currency_actions(
+            default_action,
+            url.as_str(),
+            format!("{} {}", format_decimal(rate), home.code()),
+            format!("{} {}", format_decimal(inverse), currency.code()),
+            format!(
+                "Copy {} {} {} to clipboard",
+                format_decimal(rate),
+                home.code(),
+                home.flag()
+            ),
+        );
+        let mut inverse_modifier = Modifier::new().with_subtitle(format!(
+            "1 {} ≃ {} {}",
+            home.code(),
+            format_decimal(inverse),
+            currency.code()
+        ));
+        if let Some(argument) = actions.inverse_arg {
+            inverse_modifier = inverse_modifier.with_arg(argument);
+        }
         let item = Item::with_arg(
             format!("{} ({})", currency.name(), currency.code()),
-            url.as_str(),
+            actions.default_arg,
         )
         .set_subtitle(format!(
             "1 {} ≃ {} {}",
@@ -236,26 +288,8 @@ fn currency_catalog_item(
         .set_match_text(format!("{} ({})", currency.name(), currency.code()))
         .set_text(ItemText::new(currency.code()).with_large_type(currency.code()))
         .set_valid(true)
-        .try_set_modifier(
-            [ModifierKey::Alt],
-            Modifier::new().with_subtitle(format!(
-                "1 {} ≃ {} {}",
-                home.code(),
-                format_decimal(inverse),
-                currency.code()
-            )),
-        )?
-        .try_set_modifier(
-            [ModifierKey::Cmd],
-            Modifier::new()
-                .with_subtitle(format!(
-                    "Copy {} {} {} to clipboard",
-                    format_decimal(rate),
-                    home.code(),
-                    home.flag()
-                ))
-                .with_arg(format!("{} {}", format_decimal(rate), home.code())),
-        )?;
+        .try_set_modifier([ModifierKey::Alt], inverse_modifier)?
+        .try_set_modifier([ModifierKey::Cmd], actions.command_modifier)?;
         return Ok(PendingItem::new(item, Some(currency.flag())));
     }
 
@@ -281,6 +315,37 @@ fn currency_catalog_item(
             .with_arg(format!("{} {}", home.name(), home.code())),
     )?;
     Ok(PendingItem::new(item, Some(currency.flag())))
+}
+
+struct CurrencyActions {
+    default_arg: String,
+    command_modifier: Modifier,
+    inverse_arg: Option<String>,
+}
+
+fn currency_actions(
+    default_action: CurrencyDefaultAction,
+    website_url: &str,
+    copy_arg: String,
+    inverse_copy_arg: String,
+    copy_subtitle: String,
+) -> CurrencyActions {
+    match default_action {
+        CurrencyDefaultAction::OpenWebsite => CurrencyActions {
+            default_arg: website_url.to_owned(),
+            command_modifier: Modifier::new()
+                .with_subtitle(copy_subtitle)
+                .with_arg(copy_arg),
+            inverse_arg: None,
+        },
+        CurrencyDefaultAction::CopyToClipboard => CurrencyActions {
+            default_arg: copy_arg,
+            command_modifier: Modifier::new()
+                .with_subtitle("Open currency-pair chart on Xe.com")
+                .with_arg(website_url),
+            inverse_arg: Some(inverse_copy_arg),
+        },
+    }
 }
 
 /// Builds Alfred items from Numbat's public unit metadata.

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,17 +23,17 @@ pub struct PendingItem {
     emoji: Option<String>,
 }
 
-/// Default Return action for rate-backed currency results.
+/// Default Return action for conversion results.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub enum CurrencyDefaultAction {
-    /// Open the currency-pair chart on Xe.com.
+pub enum DefaultAction {
+    /// Open the result's website.
     #[default]
     OpenWebsite,
     /// Copy the converted value to the clipboard.
     CopyToClipboard,
 }
 
-impl CurrencyDefaultAction {
+impl DefaultAction {
     /// Parses the stored Alfred preference, falling back to the website action.
     #[must_use]
     pub fn from_preference(value: Option<&str>) -> Self {
@@ -88,7 +88,8 @@ pub fn invalid_item(message: Option<&str>) -> Item {
 pub fn conversion_item(
     query: &str,
     home: Currency,
-    default_action: CurrencyDefaultAction,
+    monetary_default_action: DefaultAction,
+    non_monetary_default_action: DefaultAction,
     rates: Option<&ExchangeRates>,
     unit_engine: &mut Option<UnitEngine>,
 ) -> Result<PendingItem> {
@@ -97,7 +98,7 @@ pub fn conversion_item(
         if parse_decimal(parts[0]).is_none() {
             return Ok(PendingItem::new(invalid_item(None), None));
         }
-        return currency_conversion_item(&parts, from, home, default_action, rates);
+        return currency_conversion_item(&parts, from, home, monetary_default_action, rates);
     }
     if parts
         .iter()
@@ -120,10 +121,19 @@ pub fn conversion_item(
                     conversion.from.symbol,
                     conversion.to.symbol
                 ))?;
-                let item = Item::with_arg(evaluation.result, url.as_str())
+                let copy_subtitle = format!("Copy {} to clipboard", evaluation.copy_value);
+                let actions = result_actions(
+                    non_monetary_default_action,
+                    url.as_str(),
+                    evaluation.copy_value,
+                    copy_subtitle,
+                    "Open conversion details on WolframAlpha.com",
+                );
+                let item = Item::with_arg(evaluation.result, actions.default_arg)
                     .set_subtitle(evaluation.legacy_fact.unwrap_or_default())
                     .set_quick_look_url(url.as_str())
-                    .set_valid(true);
+                    .set_valid(true)
+                    .try_set_modifier([ModifierKey::Cmd], actions.command_modifier)?;
                 Ok(PendingItem::new(item, evaluation.emoji))
             }
             Err(error) => Ok(PendingItem::new(
@@ -136,10 +146,22 @@ pub fn conversion_item(
     match engine.evaluate_native(query) {
         Ok(evaluation) => {
             let url = wolfram_url(query)?;
-            let item = Item::with_arg(format!("{query} = {}", evaluation.result), url.as_str())
-                .set_subtitle("Evaluated with Numbat")
-                .set_quick_look_url(url.as_str())
-                .set_valid(true);
+            let copy_subtitle = format!("Copy {} to clipboard", evaluation.copy_value);
+            let actions = result_actions(
+                non_monetary_default_action,
+                url.as_str(),
+                evaluation.copy_value,
+                copy_subtitle,
+                "Open evaluation details on WolframAlpha.com",
+            );
+            let item = Item::with_arg(
+                format!("{query} = {}", evaluation.result),
+                actions.default_arg,
+            )
+            .set_subtitle("Evaluated with Numbat")
+            .set_quick_look_url(url.as_str())
+            .set_valid(true)
+            .try_set_modifier([ModifierKey::Cmd], actions.command_modifier)?;
             Ok(PendingItem::new(item, None))
         }
         Err(_) => Ok(PendingItem::new(invalid_item(None), None)),
@@ -150,7 +172,7 @@ fn currency_conversion_item(
     parts: &[&str],
     from: Currency,
     home: Currency,
-    default_action: CurrencyDefaultAction,
+    default_action: DefaultAction,
     rates: Option<&ExchangeRates>,
 ) -> Result<PendingItem> {
     let to_code = match parts {
@@ -182,17 +204,17 @@ fn currency_conversion_item(
         .checked_mul(inverted_rate)
         .ok_or_else(|| anyhow!("inverse currency conversion overflowed"))?;
     let url = xe_url(from, to)?;
-    let actions = currency_actions(
+    let actions = result_actions(
         default_action,
         url.as_str(),
         format!("{} {}", format_decimal(converted), to.code()),
-        format!("{} {}", format_decimal(inverted), from.code()),
         format!(
             "Copy {} {} {} to clipboard",
             format_decimal(converted),
             to.code(),
             to.flag()
         ),
+        "Open currency-pair chart on Xe.com",
     );
     let mut inverse_modifier = Modifier::new().with_subtitle(format!(
         "{} {} {} ≃ {} {} {}",
@@ -203,8 +225,9 @@ fn currency_conversion_item(
         from.code(),
         from.flag()
     ));
-    if let Some(argument) = actions.inverse_arg {
-        inverse_modifier = inverse_modifier.with_arg(argument);
+    if default_action == DefaultAction::CopyToClipboard {
+        inverse_modifier =
+            inverse_modifier.with_arg(format!("{} {}", format_decimal(inverted), from.code()));
     }
     let item = Item::with_arg(
         format!(
@@ -232,7 +255,7 @@ fn currency_conversion_item(
 /// Returns an error if a URL or modifier cannot be built.
 pub fn currency_items(
     home: Currency,
-    default_action: CurrencyDefaultAction,
+    default_action: DefaultAction,
     rates: Option<&ExchangeRates>,
 ) -> Result<Vec<PendingItem>> {
     CURRENCIES
@@ -245,7 +268,7 @@ pub fn currency_items(
 fn currency_catalog_item(
     currency: Currency,
     home: Currency,
-    default_action: CurrencyDefaultAction,
+    default_action: DefaultAction,
     rates: Option<&ExchangeRates>,
 ) -> Result<PendingItem> {
     if currency != home
@@ -253,17 +276,17 @@ fn currency_catalog_item(
     {
         let inverse = divide_like_dart(Decimal::ONE, rate)?;
         let url = xe_url(currency, home)?;
-        let actions = currency_actions(
+        let actions = result_actions(
             default_action,
             url.as_str(),
             format!("{} {}", format_decimal(rate), home.code()),
-            format!("{} {}", format_decimal(inverse), currency.code()),
             format!(
                 "Copy {} {} {} to clipboard",
                 format_decimal(rate),
                 home.code(),
                 home.flag()
             ),
+            "Open currency-pair chart on Xe.com",
         );
         let mut inverse_modifier = Modifier::new().with_subtitle(format!(
             "1 {} ≃ {} {}",
@@ -271,8 +294,12 @@ fn currency_catalog_item(
             format_decimal(inverse),
             currency.code()
         ));
-        if let Some(argument) = actions.inverse_arg {
-            inverse_modifier = inverse_modifier.with_arg(argument);
+        if default_action == DefaultAction::CopyToClipboard {
+            inverse_modifier = inverse_modifier.with_arg(format!(
+                "{} {}",
+                format_decimal(inverse),
+                currency.code()
+            ));
         }
         let item = Item::with_arg(
             format!("{} ({})", currency.name(), currency.code()),
@@ -317,33 +344,30 @@ fn currency_catalog_item(
     Ok(PendingItem::new(item, Some(currency.flag())))
 }
 
-struct CurrencyActions {
+struct ResultActions {
     default_arg: String,
     command_modifier: Modifier,
-    inverse_arg: Option<String>,
 }
 
-fn currency_actions(
-    default_action: CurrencyDefaultAction,
+fn result_actions(
+    default_action: DefaultAction,
     website_url: &str,
     copy_arg: String,
-    inverse_copy_arg: String,
     copy_subtitle: String,
-) -> CurrencyActions {
+    website_subtitle: &str,
+) -> ResultActions {
     match default_action {
-        CurrencyDefaultAction::OpenWebsite => CurrencyActions {
+        DefaultAction::OpenWebsite => ResultActions {
             default_arg: website_url.to_owned(),
             command_modifier: Modifier::new()
                 .with_subtitle(copy_subtitle)
                 .with_arg(copy_arg),
-            inverse_arg: None,
         },
-        CurrencyDefaultAction::CopyToClipboard => CurrencyActions {
+        DefaultAction::CopyToClipboard => ResultActions {
             default_arg: copy_arg,
             command_modifier: Modifier::new()
-                .with_subtitle("Open currency-pair chart on Xe.com")
+                .with_subtitle(website_subtitle)
                 .with_arg(website_url),
-            inverse_arg: Some(inverse_copy_arg),
         },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,13 @@
 #![forbid(unsafe_code)]
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::Duration;
 
 use alfred_convert::app::{
-    PendingItem, conversion_item, currency_items, invalid_item, placeholder_item, unit_items,
+    CurrencyDefaultAction, PendingItem, conversion_item, currency_items, invalid_item,
+    placeholder_item, unit_items,
 };
 use alfred_convert::cli::Cli;
 use alfred_convert::currency::{Currency, EcbClient, ExchangeRateCache};
@@ -65,13 +67,17 @@ fn populate_workflow(workflow: &mut Workflow, cli: &Cli) -> Result<()> {
         eprintln!("Query: \"{query}\"");
     }
     let directory = workflow_directory()?;
-    let home = home_currency(workflow, &directory)?;
+    let settings = workflow_settings(workflow, &directory)?;
 
     if cli.currencies {
         let rates = latest_rates(&directory, cli.verbose)?;
         return add_pending_items(
             workflow,
-            currency_items(home, rates.as_ref())?,
+            currency_items(
+                settings.home_currency,
+                settings.currency_default_action,
+                rates.as_ref(),
+            )?,
             &directory,
             cli.verbose,
         );
@@ -97,7 +103,13 @@ fn populate_workflow(workflow: &mut Workflow, cli: &Cli) -> Result<()> {
         None
     };
     let mut unit_engine = None;
-    let item = conversion_item(&query, home, rates.as_ref(), &mut unit_engine)?;
+    let item = conversion_item(
+        &query,
+        settings.home_currency,
+        settings.currency_default_action,
+        rates.as_ref(),
+        &mut unit_engine,
+    )?;
     add_pending_items(workflow, vec![item], &directory, cli.verbose)
 }
 
@@ -146,17 +158,37 @@ fn add_pending_items(
     Ok(())
 }
 
-fn home_currency(workflow: &Workflow, directory: &Path) -> Result<Currency> {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct WorkflowSettings {
+    home_currency: Currency,
+    currency_default_action: CurrencyDefaultAction,
+}
+
+fn workflow_settings(workflow: &Workflow, directory: &Path) -> Result<WorkflowSettings> {
     let defaults =
         workflow.get_user_defaults(directory.join("info.plist"), directory.join("prefs.plist"))?;
-    let configured = match defaults.get("default_currency") {
+    workflow_settings_from_defaults(&defaults)
+}
+
+fn workflow_settings_from_defaults(
+    defaults: &BTreeMap<String, UserConfiguration>,
+) -> Result<WorkflowSettings> {
+    let configured_currency = match defaults.get("default_currency") {
         Some(UserConfiguration::Select(configuration)) => Some(configuration.config.value.as_str()),
         _ => None,
     };
-    configured
+    let home_currency = configured_currency
         .and_then(Currency::from_code)
         .or_else(|| Currency::from_code("USD"))
-        .ok_or_else(|| anyhow!("USD currency metadata is missing"))
+        .ok_or_else(|| anyhow!("USD currency metadata is missing"))?;
+    let configured_action = match defaults.get("default_action") {
+        Some(UserConfiguration::Select(configuration)) => Some(configuration.config.value.as_str()),
+        _ => None,
+    };
+    Ok(WorkflowSettings {
+        home_currency,
+        currency_default_action: CurrencyDefaultAction::from_preference(configured_action),
+    })
 }
 
 fn workflow_directory() -> Result<PathBuf> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,8 @@ use std::process::ExitCode;
 use std::time::Duration;
 
 use alfred_convert::app::{
-    CurrencyDefaultAction, PendingItem, conversion_item, currency_items, invalid_item,
-    placeholder_item, unit_items,
+    DefaultAction, PendingItem, conversion_item, currency_items, invalid_item, placeholder_item,
+    unit_items,
 };
 use alfred_convert::cli::Cli;
 use alfred_convert::currency::{Currency, EcbClient, ExchangeRateCache};
@@ -75,7 +75,7 @@ fn populate_workflow(workflow: &mut Workflow, cli: &Cli) -> Result<()> {
             workflow,
             currency_items(
                 settings.home_currency,
-                settings.currency_default_action,
+                settings.default_monetary_action,
                 rates.as_ref(),
             )?,
             &directory,
@@ -106,7 +106,8 @@ fn populate_workflow(workflow: &mut Workflow, cli: &Cli) -> Result<()> {
     let item = conversion_item(
         &query,
         settings.home_currency,
-        settings.currency_default_action,
+        settings.default_monetary_action,
+        settings.default_non_monetary_action,
         rates.as_ref(),
         &mut unit_engine,
     )?;
@@ -161,7 +162,8 @@ fn add_pending_items(
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct WorkflowSettings {
     home_currency: Currency,
-    currency_default_action: CurrencyDefaultAction,
+    default_monetary_action: DefaultAction,
+    default_non_monetary_action: DefaultAction,
 }
 
 fn workflow_settings(workflow: &Workflow, directory: &Path) -> Result<WorkflowSettings> {
@@ -181,13 +183,18 @@ fn workflow_settings_from_defaults(
         .and_then(Currency::from_code)
         .or_else(|| Currency::from_code("USD"))
         .ok_or_else(|| anyhow!("USD currency metadata is missing"))?;
-    let configured_action = match defaults.get("default_action") {
+    let configured_monetary_action = match defaults.get("default_monetary_action") {
+        Some(UserConfiguration::Select(configuration)) => Some(configuration.config.value.as_str()),
+        _ => None,
+    };
+    let configured_non_monetary_action = match defaults.get("default_non_monetary_action") {
         Some(UserConfiguration::Select(configuration)) => Some(configuration.config.value.as_str()),
         _ => None,
     };
     Ok(WorkflowSettings {
         home_currency,
-        currency_default_action: CurrencyDefaultAction::from_preference(configured_action),
+        default_monetary_action: DefaultAction::from_preference(configured_monetary_action),
+        default_non_monetary_action: DefaultAction::from_preference(configured_non_monetary_action),
     })
 }
 

--- a/src/tests/app.rs
+++ b/src/tests/app.rs
@@ -1,7 +1,8 @@
 use crate::app::{
-    CurrencyDefaultAction, conversion_item, currency_items, invalid_item, placeholder_item,
+    DefaultAction, conversion_item, currency_items, invalid_item, placeholder_item, unit_items,
 };
 use crate::currency::{Currency, ExchangeRates};
+use crate::units::UnitListing;
 use jiff::Timestamp;
 use rust_decimal::Decimal;
 
@@ -25,12 +26,29 @@ fn native_numbat_query_should_not_require_a_separate_numeric_token() -> anyhow::
     let pending = conversion_item(
         "2in to cm",
         home,
-        CurrencyDefaultAction::OpenWebsite,
+        DefaultAction::OpenWebsite,
+        DefaultAction::OpenWebsite,
         None,
         &mut engine,
     )?;
     let item = pending.into_item(None);
-    assert_eq!(item.title(), "2in to cm = 5.08 cm");
+    let command = item.modifiers().and_then(|modifiers| modifiers.get("cmd"));
+    assert_eq!(
+        (
+            item.title(),
+            item.arg(),
+            item.quick_look_url(),
+            command.and_then(alfred_workflow_rs::Modifier::arg),
+            command.and_then(alfred_workflow_rs::Modifier::subtitle),
+        ),
+        (
+            "2in to cm = 5.08 cm",
+            Some("https://www.wolframalpha.com/input?i=2in+to+cm"),
+            Some("https://www.wolframalpha.com/input?i=2in+to+cm"),
+            Some("5.08 cm"),
+            Some("Copy 5.08 cm to clipboard"),
+        )
+    );
     Ok(())
 }
 
@@ -41,7 +59,8 @@ fn legacy_symbol_should_be_used_in_item_and_wolfram_action() -> anyhow::Result<(
     let item = conversion_item(
         "60 ' deg",
         home,
-        CurrencyDefaultAction::OpenWebsite,
+        DefaultAction::OpenWebsite,
+        DefaultAction::OpenWebsite,
         None,
         &mut engine,
     )?
@@ -54,12 +73,28 @@ fn legacy_symbol_should_be_used_in_item_and_wolfram_action() -> anyhow::Result<(
                 .find(|(name, _)| name == "i")
                 .map(|(_, value)| value.into_owned())
         });
+    let command_arg = item
+        .modifiers()
+        .and_then(|modifiers| modifiers.get("cmd"))
+        .and_then(alfred_workflow_rs::Modifier::arg);
+    let command_subtitle = item
+        .modifiers()
+        .and_then(|modifiers| modifiers.get("cmd"))
+        .and_then(alfred_workflow_rs::Modifier::subtitle);
     assert_eq!(
-        (item.title(), item.subtitle(), wolfram_query.as_deref()),
+        (
+            item.title(),
+            item.subtitle(),
+            wolfram_query.as_deref(),
+            command_arg,
+            command_subtitle,
+        ),
         (
             "60 ' = 1 °",
             Some("Based on the fact that 1 ' = 0.017 °"),
-            Some("60.0 ' to °")
+            Some("60.0 ' to °"),
+            Some("1 °"),
+            Some("Copy 1 ° to clipboard"),
         )
     );
     Ok(())
@@ -73,7 +108,8 @@ fn trailing_currency_tokens_should_be_rejected_instead_of_ignored() -> anyhow::R
     let pending = conversion_item(
         "10 EUR USD ignored",
         home,
-        CurrencyDefaultAction::OpenWebsite,
+        DefaultAction::OpenWebsite,
+        DefaultAction::CopyToClipboard,
         Some(&rates),
         &mut engine,
     )?;
@@ -88,7 +124,8 @@ fn malformed_currency_amount_should_not_initialize_numbat() -> anyhow::Result<()
     let pending = conversion_item(
         "abc USD EUR",
         home,
-        CurrencyDefaultAction::OpenWebsite,
+        DefaultAction::OpenWebsite,
+        DefaultAction::CopyToClipboard,
         None,
         &mut engine,
     )?;
@@ -106,7 +143,8 @@ fn currency_item_should_open_xe_by_default_and_copy_with_command() -> anyhow::Re
     let item = conversion_item(
         "10 EUR USD",
         home,
-        CurrencyDefaultAction::OpenWebsite,
+        DefaultAction::OpenWebsite,
+        DefaultAction::CopyToClipboard,
         Some(&rates),
         &mut engine,
     )?
@@ -146,7 +184,8 @@ fn currency_item_should_copy_by_default_and_open_xe_with_command() -> anyhow::Re
     let item = conversion_item(
         "10 EUR USD",
         home,
-        CurrencyDefaultAction::CopyToClipboard,
+        DefaultAction::CopyToClipboard,
+        DefaultAction::OpenWebsite,
         Some(&rates),
         &mut engine,
     )?
@@ -189,7 +228,7 @@ fn currency_item_should_copy_by_default_and_open_xe_with_command() -> anyhow::Re
 fn currency_catalogue_should_open_xe_by_default_and_copy_with_command() -> anyhow::Result<()> {
     let items = currency_items(
         currency("USD")?,
-        CurrencyDefaultAction::OpenWebsite,
+        DefaultAction::OpenWebsite,
         Some(&sample_rates()?),
     )?;
     let item = items
@@ -223,7 +262,7 @@ fn currency_catalogue_should_open_xe_by_default_and_copy_with_command() -> anyho
 fn currency_catalogue_should_apply_copy_default_to_rate_backed_rows() -> anyhow::Result<()> {
     let items = currency_items(
         currency("USD")?,
-        CurrencyDefaultAction::CopyToClipboard,
+        DefaultAction::CopyToClipboard,
         Some(&sample_rates()?),
     )?;
     let item = items
@@ -267,11 +306,7 @@ fn currency_catalogue_should_apply_copy_default_to_rate_backed_rows() -> anyhow:
 
 #[test]
 fn currency_catalogue_should_keep_oanda_fallback_in_copy_mode() -> anyhow::Result<()> {
-    let items = currency_items(
-        currency("USD")?,
-        CurrencyDefaultAction::CopyToClipboard,
-        None,
-    )?;
+    let items = currency_items(currency("USD")?, DefaultAction::CopyToClipboard, None)?;
     let item = items
         .into_iter()
         .map(|pending| pending.into_item(None))
@@ -292,53 +327,138 @@ fn currency_catalogue_should_keep_oanda_fallback_in_copy_mode() -> anyhow::Resul
 }
 
 #[test]
-fn currency_default_action_should_fall_back_to_open_website() {
+fn default_action_should_fall_back_to_open_website() {
     assert_eq!(
         (
-            CurrencyDefaultAction::default(),
-            CurrencyDefaultAction::from_preference(None),
-            CurrencyDefaultAction::from_preference(Some("unexpected")),
+            DefaultAction::default(),
+            DefaultAction::from_preference(None),
+            DefaultAction::from_preference(Some("unexpected")),
         ),
         (
-            CurrencyDefaultAction::OpenWebsite,
-            CurrencyDefaultAction::OpenWebsite,
-            CurrencyDefaultAction::OpenWebsite,
+            DefaultAction::OpenWebsite,
+            DefaultAction::OpenWebsite,
+            DefaultAction::OpenWebsite,
         )
     );
 }
 
 #[test]
-fn currency_default_action_should_parse_open_website_preference() {
+fn default_action_should_parse_open_website_preference() {
     assert_eq!(
-        CurrencyDefaultAction::from_preference(Some("open_website")),
-        CurrencyDefaultAction::OpenWebsite
+        DefaultAction::from_preference(Some("open_website")),
+        DefaultAction::OpenWebsite
     );
 }
 
 #[test]
-fn currency_default_action_should_parse_copy_preference() {
+fn default_action_should_parse_copy_preference() {
     assert_eq!(
-        CurrencyDefaultAction::from_preference(Some("copy_to_clipboard")),
-        CurrencyDefaultAction::CopyToClipboard
+        DefaultAction::from_preference(Some("copy_to_clipboard")),
+        DefaultAction::CopyToClipboard
     );
 }
 
 #[test]
-fn unit_conversion_should_keep_its_wolfram_action() -> anyhow::Result<()> {
+fn native_unit_conversion_should_copy_only_the_value_by_default() -> anyhow::Result<()> {
     let home = currency("USD")?;
     let mut engine = None;
     let item = conversion_item(
         "2in to cm",
         home,
-        CurrencyDefaultAction::CopyToClipboard,
+        DefaultAction::OpenWebsite,
+        DefaultAction::CopyToClipboard,
+        None,
+        &mut engine,
+    )?
+    .into_item(None);
+    let command = item.modifiers().and_then(|modifiers| modifiers.get("cmd"));
+    assert_eq!(
+        (
+            item.title(),
+            item.arg(),
+            item.quick_look_url(),
+            command.and_then(alfred_workflow_rs::Modifier::arg),
+            command.and_then(alfred_workflow_rs::Modifier::subtitle),
+        ),
+        (
+            "2in to cm = 5.08 cm",
+            Some("5.08 cm"),
+            Some("https://www.wolframalpha.com/input?i=2in+to+cm"),
+            Some("https://www.wolframalpha.com/input?i=2in+to+cm"),
+            Some("Open evaluation details on WolframAlpha.com"),
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn legacy_unit_conversion_should_copy_only_the_value_by_default() -> anyhow::Result<()> {
+    let home = currency("USD")?;
+    let mut engine = None;
+    let item = conversion_item(
+        "10 mi km",
+        home,
+        DefaultAction::OpenWebsite,
+        DefaultAction::CopyToClipboard,
+        None,
+        &mut engine,
+    )?
+    .into_item(None);
+    let command = item.modifiers().and_then(|modifiers| modifiers.get("cmd"));
+    assert_eq!(
+        (
+            item.title(),
+            item.subtitle(),
+            item.arg(),
+            item.quick_look_url(),
+            command.and_then(alfred_workflow_rs::Modifier::arg),
+            command.and_then(alfred_workflow_rs::Modifier::subtitle),
+        ),
+        (
+            "10 mi = 16.093 km",
+            Some("Based on the fact that 1 mi = 1.609 km"),
+            Some("16.093 km"),
+            Some("https://www.wolframalpha.com/input?i=10.0+mi+to+km"),
+            Some("https://www.wolframalpha.com/input?i=10.0+mi+to+km"),
+            Some("Open conversion details on WolframAlpha.com"),
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn invalid_unit_expression_should_not_receive_result_actions() -> anyhow::Result<()> {
+    let home = currency("USD")?;
+    let mut engine = None;
+    let item = conversion_item(
+        "not a valid expression",
+        home,
+        DefaultAction::CopyToClipboard,
+        DefaultAction::CopyToClipboard,
         None,
         &mut engine,
     )?
     .into_item(None);
     assert_eq!(
-        (item.arg(), item.modifiers()),
-        (Some("https://www.wolframalpha.com/input?i=2in+to+cm"), None,)
+        (item.title(), item.arg(), item.modifiers()),
+        ("Invalid format.", None, None)
     );
+    Ok(())
+}
+
+#[test]
+fn unit_catalogue_should_keep_copying_the_identifier() -> anyhow::Result<()> {
+    let item = unit_items(&[UnitListing {
+        identifier: "metre".to_owned(),
+        name: "meter".to_owned(),
+        dimension: "Length".to_owned(),
+        aliases: vec!["m".to_owned()],
+    }])
+    .into_iter()
+    .next()
+    .ok_or_else(|| anyhow::anyhow!("unit catalogue item missing"))?
+    .into_item(None);
+    assert_eq!((item.arg(), item.modifiers()), (Some("metre"), None));
     Ok(())
 }
 

--- a/src/tests/app.rs
+++ b/src/tests/app.rs
@@ -1,4 +1,6 @@
-use crate::app::{conversion_item, invalid_item, placeholder_item};
+use crate::app::{
+    CurrencyDefaultAction, conversion_item, currency_items, invalid_item, placeholder_item,
+};
 use crate::currency::{Currency, ExchangeRates};
 use jiff::Timestamp;
 use rust_decimal::Decimal;
@@ -20,7 +22,13 @@ fn invalid_item_should_keep_the_historical_usage() {
 fn native_numbat_query_should_not_require_a_separate_numeric_token() -> anyhow::Result<()> {
     let home = Currency::from_code("USD").ok_or_else(|| anyhow::anyhow!("USD missing"))?;
     let mut engine = None;
-    let pending = conversion_item("2in to cm", home, None, &mut engine)?;
+    let pending = conversion_item(
+        "2in to cm",
+        home,
+        CurrencyDefaultAction::OpenWebsite,
+        None,
+        &mut engine,
+    )?;
     let item = pending.into_item(None);
     assert_eq!(item.title(), "2in to cm = 5.08 cm");
     Ok(())
@@ -30,7 +38,14 @@ fn native_numbat_query_should_not_require_a_separate_numeric_token() -> anyhow::
 fn legacy_symbol_should_be_used_in_item_and_wolfram_action() -> anyhow::Result<()> {
     let home = Currency::from_code("USD").ok_or_else(|| anyhow::anyhow!("USD missing"))?;
     let mut engine = None;
-    let item = conversion_item("60 ' deg", home, None, &mut engine)?.into_item(None);
+    let item = conversion_item(
+        "60 ' deg",
+        home,
+        CurrencyDefaultAction::OpenWebsite,
+        None,
+        &mut engine,
+    )?
+    .into_item(None);
     let wolfram_query = item
         .arg()
         .and_then(|argument| url::Url::parse(argument).ok())
@@ -55,7 +70,13 @@ fn trailing_currency_tokens_should_be_rejected_instead_of_ignored() -> anyhow::R
     let home = currency("USD")?;
     let rates = sample_rates()?;
     let mut engine = None;
-    let pending = conversion_item("10 EUR USD ignored", home, Some(&rates), &mut engine)?;
+    let pending = conversion_item(
+        "10 EUR USD ignored",
+        home,
+        CurrencyDefaultAction::OpenWebsite,
+        Some(&rates),
+        &mut engine,
+    )?;
     assert_eq!(pending.into_item(None).title(), "Invalid format.");
     Ok(())
 }
@@ -64,7 +85,13 @@ fn trailing_currency_tokens_should_be_rejected_instead_of_ignored() -> anyhow::R
 fn malformed_currency_amount_should_not_initialize_numbat() -> anyhow::Result<()> {
     let home = currency("USD")?;
     let mut engine = None;
-    let pending = conversion_item("abc USD EUR", home, None, &mut engine)?;
+    let pending = conversion_item(
+        "abc USD EUR",
+        home,
+        CurrencyDefaultAction::OpenWebsite,
+        None,
+        &mut engine,
+    )?;
 
     assert_eq!(pending.into_item(None).title(), "Invalid format.");
     assert!(engine.is_none());
@@ -72,15 +99,245 @@ fn malformed_currency_amount_should_not_initialize_numbat() -> anyhow::Result<()
 }
 
 #[test]
-fn currency_item_should_preserve_conversion_title_and_xe_action() -> anyhow::Result<()> {
+fn currency_item_should_open_xe_by_default_and_copy_with_command() -> anyhow::Result<()> {
     let home = currency("USD")?;
     let rates = sample_rates()?;
     let mut engine = None;
-    let item = conversion_item("10 EUR USD", home, Some(&rates), &mut engine)?.into_item(None);
-    assert_eq!(item.title(), "10 EUR 🇪🇺 ≃ 11.732 USD 🇺🇸");
-    assert!(
-        item.arg()
-            .is_some_and(|argument| argument.starts_with("https://www.xe.com/"))
+    let item = conversion_item(
+        "10 EUR USD",
+        home,
+        CurrencyDefaultAction::OpenWebsite,
+        Some(&rates),
+        &mut engine,
+    )?
+    .into_item(None);
+    let command = item.modifiers().and_then(|modifiers| modifiers.get("cmd"));
+    let option = item.modifiers().and_then(|modifiers| modifiers.get("alt"));
+    assert_eq!(
+        (
+            item.title(),
+            item.subtitle(),
+            item.arg(),
+            item.quick_look_url(),
+            command.and_then(alfred_workflow_rs::Modifier::arg),
+            command.and_then(alfred_workflow_rs::Modifier::subtitle),
+            option.and_then(alfred_workflow_rs::Modifier::arg),
+            option.and_then(alfred_workflow_rs::Modifier::subtitle),
+        ),
+        (
+            "10 EUR 🇪🇺 ≃ 11.732 USD 🇺🇸",
+            Some("Based on ECB exchange rates from Aug 21, 2026"),
+            Some("https://www.xe.com/currencycharts?from=EUR&to=USD"),
+            Some("https://www.xe.com/currencycharts?from=EUR&to=USD"),
+            Some("11.732 USD"),
+            Some("Copy 11.732 USD 🇺🇸 to clipboard"),
+            None,
+            Some("10 USD 🇺🇸 ≃ 8.523 EUR 🇪🇺"),
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn currency_item_should_copy_by_default_and_open_xe_with_command() -> anyhow::Result<()> {
+    let home = currency("USD")?;
+    let rates = sample_rates()?;
+    let mut engine = None;
+    let item = conversion_item(
+        "10 EUR USD",
+        home,
+        CurrencyDefaultAction::CopyToClipboard,
+        Some(&rates),
+        &mut engine,
+    )?
+    .into_item(None);
+    let modifiers = item
+        .modifiers()
+        .ok_or_else(|| anyhow::anyhow!("currency modifiers missing"))?;
+    assert_eq!(
+        (
+            item.arg(),
+            item.subtitle(),
+            item.quick_look_url(),
+            modifiers
+                .get("cmd")
+                .and_then(alfred_workflow_rs::Modifier::arg),
+            modifiers
+                .get("cmd")
+                .and_then(alfred_workflow_rs::Modifier::subtitle),
+            modifiers
+                .get("alt")
+                .and_then(alfred_workflow_rs::Modifier::arg),
+            modifiers
+                .get("alt")
+                .and_then(alfred_workflow_rs::Modifier::subtitle),
+        ),
+        (
+            Some("11.732 USD"),
+            Some("Based on ECB exchange rates from Aug 21, 2026"),
+            Some("https://www.xe.com/currencycharts?from=EUR&to=USD"),
+            Some("https://www.xe.com/currencycharts?from=EUR&to=USD"),
+            Some("Open currency-pair chart on Xe.com"),
+            Some("8.523 EUR"),
+            Some("10 USD 🇺🇸 ≃ 8.523 EUR 🇪🇺"),
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn currency_catalogue_should_open_xe_by_default_and_copy_with_command() -> anyhow::Result<()> {
+    let items = currency_items(
+        currency("USD")?,
+        CurrencyDefaultAction::OpenWebsite,
+        Some(&sample_rates()?),
+    )?;
+    let item = items
+        .into_iter()
+        .map(|pending| pending.into_item(None))
+        .find(|item| item.title() == "Euro (EUR)")
+        .ok_or_else(|| anyhow::anyhow!("EUR catalogue item missing"))?;
+    let modifiers = item
+        .modifiers()
+        .ok_or_else(|| anyhow::anyhow!("currency modifiers missing"))?;
+    assert_eq!(
+        (
+            item.arg(),
+            modifiers
+                .get("cmd")
+                .and_then(alfred_workflow_rs::Modifier::arg),
+            modifiers
+                .get("alt")
+                .and_then(alfred_workflow_rs::Modifier::arg),
+        ),
+        (
+            Some("https://www.xe.com/currencycharts?from=EUR&to=USD"),
+            Some("1.173 USD"),
+            None,
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn currency_catalogue_should_apply_copy_default_to_rate_backed_rows() -> anyhow::Result<()> {
+    let items = currency_items(
+        currency("USD")?,
+        CurrencyDefaultAction::CopyToClipboard,
+        Some(&sample_rates()?),
+    )?;
+    let item = items
+        .into_iter()
+        .map(|pending| pending.into_item(None))
+        .find(|item| item.title() == "Euro (EUR)")
+        .ok_or_else(|| anyhow::anyhow!("EUR catalogue item missing"))?;
+    let modifiers = item
+        .modifiers()
+        .ok_or_else(|| anyhow::anyhow!("currency modifiers missing"))?;
+    assert_eq!(
+        (
+            item.arg(),
+            item.subtitle(),
+            item.quick_look_url(),
+            modifiers
+                .get("cmd")
+                .and_then(alfred_workflow_rs::Modifier::arg),
+            modifiers
+                .get("cmd")
+                .and_then(alfred_workflow_rs::Modifier::subtitle),
+            modifiers
+                .get("alt")
+                .and_then(alfred_workflow_rs::Modifier::arg),
+            modifiers
+                .get("alt")
+                .and_then(alfred_workflow_rs::Modifier::subtitle),
+        ),
+        (
+            Some("1.173 USD"),
+            Some("1 EUR ≃ 1.173 USD"),
+            Some("https://www.xe.com/currencycharts?from=EUR&to=USD"),
+            Some("https://www.xe.com/currencycharts?from=EUR&to=USD"),
+            Some("Open currency-pair chart on Xe.com"),
+            Some("0.852 EUR"),
+            Some("1 USD ≃ 0.852 EUR"),
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn currency_catalogue_should_keep_oanda_fallback_in_copy_mode() -> anyhow::Result<()> {
+    let items = currency_items(
+        currency("USD")?,
+        CurrencyDefaultAction::CopyToClipboard,
+        None,
+    )?;
+    let item = items
+        .into_iter()
+        .map(|pending| pending.into_item(None))
+        .find(|item| item.title() == "US dollar (USD)")
+        .ok_or_else(|| anyhow::anyhow!("USD catalogue item missing"))?;
+    let command_arg = item
+        .modifiers()
+        .and_then(|modifiers| modifiers.get("cmd"))
+        .and_then(alfred_workflow_rs::Modifier::arg);
+    assert_eq!(
+        (item.arg(), command_arg),
+        (
+            Some("https://www.oanda.com/currency-converter/en/currencies/majors/usd/"),
+            Some("US dollar USD"),
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn currency_default_action_should_fall_back_to_open_website() {
+    assert_eq!(
+        (
+            CurrencyDefaultAction::default(),
+            CurrencyDefaultAction::from_preference(None),
+            CurrencyDefaultAction::from_preference(Some("unexpected")),
+        ),
+        (
+            CurrencyDefaultAction::OpenWebsite,
+            CurrencyDefaultAction::OpenWebsite,
+            CurrencyDefaultAction::OpenWebsite,
+        )
+    );
+}
+
+#[test]
+fn currency_default_action_should_parse_open_website_preference() {
+    assert_eq!(
+        CurrencyDefaultAction::from_preference(Some("open_website")),
+        CurrencyDefaultAction::OpenWebsite
+    );
+}
+
+#[test]
+fn currency_default_action_should_parse_copy_preference() {
+    assert_eq!(
+        CurrencyDefaultAction::from_preference(Some("copy_to_clipboard")),
+        CurrencyDefaultAction::CopyToClipboard
+    );
+}
+
+#[test]
+fn unit_conversion_should_keep_its_wolfram_action() -> anyhow::Result<()> {
+    let home = currency("USD")?;
+    let mut engine = None;
+    let item = conversion_item(
+        "2in to cm",
+        home,
+        CurrencyDefaultAction::CopyToClipboard,
+        None,
+        &mut engine,
+    )?
+    .into_item(None);
+    assert_eq!(
+        (item.arg(), item.modifiers()),
+        (Some("https://www.wolframalpha.com/input?i=2in+to+cm"), None,)
     );
     Ok(())
 }

--- a/src/tests/main.rs
+++ b/src/tests/main.rs
@@ -1,6 +1,15 @@
-use alfred_workflow_rs::{AutomaticCache, Workflow};
+use std::collections::BTreeMap;
 
-use super::{query_requires_exchange_rates, replace_items_with_runtime_error};
+use alfred_convert::app::CurrencyDefaultAction;
+use alfred_workflow_rs::{
+    AutomaticCache, CheckBoxConfiguration, CheckBoxUserConfiguration, SelectConfiguration,
+    SelectUserConfiguration, UserConfiguration, Workflow,
+};
+
+use super::{
+    query_requires_exchange_rates, replace_items_with_runtime_error, update_item,
+    workflow_settings_from_defaults,
+};
 
 #[test]
 fn runtime_error_should_disable_automatic_cache() -> anyhow::Result<()> {
@@ -19,4 +28,73 @@ fn valid_currency_query_should_require_exchange_rates() {
 #[test]
 fn malformed_currency_amount_should_not_require_exchange_rates() {
     assert!(!query_requires_exchange_rates("abc USD EUR"));
+}
+
+#[test]
+fn update_item_should_keep_the_update_action() {
+    let item = update_item();
+    assert_eq!(
+        (item.title(), item.arg()),
+        ("Auto-Update available!", Some("update:workflow"))
+    );
+}
+
+#[test]
+fn workflow_settings_should_load_both_select_preferences() -> anyhow::Result<()> {
+    let defaults = BTreeMap::from([
+        select_configuration("default_currency", "EUR"),
+        select_configuration("default_action", "copy_to_clipboard"),
+    ]);
+    let settings = workflow_settings_from_defaults(&defaults)?;
+    assert_eq!(
+        (
+            settings.home_currency.code(),
+            settings.currency_default_action
+        ),
+        ("EUR", CurrencyDefaultAction::CopyToClipboard)
+    );
+    Ok(())
+}
+
+#[test]
+fn workflow_settings_should_ignore_wrong_action_configuration_type() -> anyhow::Result<()> {
+    let defaults = BTreeMap::from([
+        select_configuration("default_currency", "USD"),
+        (
+            "default_action".to_owned(),
+            UserConfiguration::CheckBox(CheckBoxUserConfiguration {
+                variable: "default_action".to_owned(),
+                description: None,
+                label: None,
+                config: CheckBoxConfiguration {
+                    default_value: true,
+                    value: true,
+                    required: false,
+                    text: None,
+                },
+            }),
+        ),
+    ]);
+    let settings = workflow_settings_from_defaults(&defaults)?;
+    assert_eq!(
+        settings.currency_default_action,
+        CurrencyDefaultAction::OpenWebsite
+    );
+    Ok(())
+}
+
+fn select_configuration(variable: &str, value: &str) -> (String, UserConfiguration) {
+    (
+        variable.to_owned(),
+        UserConfiguration::Select(SelectUserConfiguration {
+            variable: variable.to_owned(),
+            description: None,
+            label: None,
+            config: SelectConfiguration {
+                default_value: value.to_owned(),
+                value: value.to_owned(),
+                pairs: Vec::new(),
+            },
+        }),
+    )
 }

--- a/src/tests/main.rs
+++ b/src/tests/main.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use alfred_convert::app::CurrencyDefaultAction;
+use alfred_convert::app::DefaultAction;
 use alfred_workflow_rs::{
     AutomaticCache, CheckBoxConfiguration, CheckBoxUserConfiguration, SelectConfiguration,
     SelectUserConfiguration, UserConfiguration, Workflow,
@@ -40,30 +40,36 @@ fn update_item_should_keep_the_update_action() {
 }
 
 #[test]
-fn workflow_settings_should_load_both_select_preferences() -> anyhow::Result<()> {
+fn workflow_settings_should_load_all_select_preferences() -> anyhow::Result<()> {
     let defaults = BTreeMap::from([
         select_configuration("default_currency", "EUR"),
-        select_configuration("default_action", "copy_to_clipboard"),
+        select_configuration("default_monetary_action", "copy_to_clipboard"),
+        select_configuration("default_non_monetary_action", "open_website"),
     ]);
     let settings = workflow_settings_from_defaults(&defaults)?;
     assert_eq!(
         (
             settings.home_currency.code(),
-            settings.currency_default_action
+            settings.default_monetary_action,
+            settings.default_non_monetary_action,
         ),
-        ("EUR", CurrencyDefaultAction::CopyToClipboard)
+        (
+            "EUR",
+            DefaultAction::CopyToClipboard,
+            DefaultAction::OpenWebsite,
+        )
     );
     Ok(())
 }
 
 #[test]
-fn workflow_settings_should_ignore_wrong_action_configuration_type() -> anyhow::Result<()> {
+fn workflow_settings_should_fall_back_for_wrong_action_configuration_type() -> anyhow::Result<()> {
     let defaults = BTreeMap::from([
         select_configuration("default_currency", "USD"),
         (
-            "default_action".to_owned(),
+            "default_monetary_action".to_owned(),
             UserConfiguration::CheckBox(CheckBoxUserConfiguration {
-                variable: "default_action".to_owned(),
+                variable: "default_monetary_action".to_owned(),
                 description: None,
                 label: None,
                 config: CheckBoxConfiguration {
@@ -74,11 +80,33 @@ fn workflow_settings_should_ignore_wrong_action_configuration_type() -> anyhow::
                 },
             }),
         ),
+        select_configuration("default_non_monetary_action", "copy_to_clipboard"),
     ]);
     let settings = workflow_settings_from_defaults(&defaults)?;
     assert_eq!(
-        settings.currency_default_action,
-        CurrencyDefaultAction::OpenWebsite
+        (
+            settings.default_monetary_action,
+            settings.default_non_monetary_action,
+        ),
+        (DefaultAction::OpenWebsite, DefaultAction::CopyToClipboard,)
+    );
+    Ok(())
+}
+
+#[test]
+fn workflow_settings_should_ignore_obsolete_and_unknown_action_values() -> anyhow::Result<()> {
+    let defaults = BTreeMap::from([
+        select_configuration("default_currency", "USD"),
+        select_configuration("default_action", "copy_to_clipboard"),
+        select_configuration("default_non_monetary_action", "unexpected"),
+    ]);
+    let settings = workflow_settings_from_defaults(&defaults)?;
+    assert_eq!(
+        (
+            settings.default_monetary_action,
+            settings.default_non_monetary_action,
+        ),
+        (DefaultAction::OpenWebsite, DefaultAction::OpenWebsite)
     );
     Ok(())
 }

--- a/src/tests/units.rs
+++ b/src/tests/units.rs
@@ -198,7 +198,10 @@ fn legacy_shorthand_should_be_evaluated_by_numbat() -> anyhow::Result<()> {
     let conversion = legacy_conversion("10 mi km")
         .ok_or_else(|| anyhow::anyhow!("legacy conversion missing"))?;
     let result = engine.evaluate_legacy(conversion)?;
-    assert_eq!(result.result, "10 mi = 16.093 km");
+    assert_eq!(
+        (result.result.as_str(), result.copy_value.as_str()),
+        ("10 mi = 16.093 km", "16.093 km")
+    );
     assert_eq!(
         result.legacy_fact.as_deref(),
         Some("Based on the fact that 1 mi = 1.609 km")
@@ -299,7 +302,10 @@ fn kilogram_force_torque_should_keep_the_dart_coefficient() -> anyhow::Result<()
 fn native_numbat_syntax_should_pass_through_unchanged() -> anyhow::Result<()> {
     let mut engine = UnitEngine::new()?;
     let result = engine.evaluate_native("2in to cm")?;
-    assert_eq!(result.result, "5.08 cm");
+    assert_eq!(
+        (result.result.as_str(), result.copy_value.as_str()),
+        ("5.08 cm", "5.08 cm")
+    );
     Ok(())
 }
 

--- a/src/units/engine.rs
+++ b/src/units/engine.rs
@@ -16,6 +16,8 @@ const COMPATIBILITY: &str = include_str!("compatibility.nbt");
 pub struct UnitEvaluation {
     /// Plain-text value produced by Numbat.
     pub result: String,
+    /// Converted value suitable for copying without the input expression.
+    pub copy_value: String,
     /// Optional legacy fact string for old shorthand queries.
     pub legacy_fact: Option<String>,
     /// Optional legacy dimension emoji.
@@ -65,8 +67,10 @@ impl UnitEngine {
     /// Returns an error for invalid expressions or statements without a value.
     pub fn evaluate_native(&mut self, expression: &str) -> Result<UnitEvaluation> {
         let value = self.evaluate(expression)?;
+        let result = plain_value(&value);
         Ok(UnitEvaluation {
-            result: plain_value(&value),
+            copy_value: result.clone(),
+            result,
             legacy_fact: None,
             emoji: None,
         })
@@ -88,14 +92,14 @@ impl UnitEngine {
         let single = self.legacy_value("1", conversion.from, conversion.to)?;
         let amount =
             parse_decimal(conversion.amount).ok_or_else(|| anyhow!("invalid decimal amount"))?;
+        let copy_value = format!("{} {}", format_decimal(converted), conversion.to.symbol);
         Ok(UnitEvaluation {
             result: format!(
-                "{} {} = {} {}",
+                "{} {} = {copy_value}",
                 format_decimal(amount),
-                conversion.from.symbol,
-                format_decimal(converted),
-                conversion.to.symbol
+                conversion.from.symbol
             ),
+            copy_value,
             legacy_fact: Some(format!(
                 "Based on the fact that 1 {} = {} {}",
                 conversion.from.symbol,


### PR DESCRIPTION
This pull request introduces configurable default actions for monetary and non-monetary conversion results, allowing users to choose between opening a website or copying the result to the clipboard when pressing <kbd>Return</kbd>. The alternate action is always available via <kbd>Cmd+Return</kbd>. The changes update both the workflow logic and the user interface/documentation to reflect this new flexibility.

**User-facing feature additions:**

* Added separate workflow preferences for "Default monetary action" and "Default non-monetary action", each allowing the user to choose whether <kbd>Return</kbd> opens the result's website or copies the value to the clipboard. <kbd>Cmd+Return</kbd> always performs the alternate action. [[1]](diffhunk://#diff-ef6dac0c1c122a5c9efd56197356cab3608e10a0ff362195e31e0bda9d4a1e7eR535-R586) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R33) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46-R49) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3) [[5]](diffhunk://#diff-ef6dac0c1c122a5c9efd56197356cab3608e10a0ff362195e31e0bda9d4a1e7eL333-R343)

**Workflow logic and code changes:**

* Introduced the `DefaultAction` enum and logic in `src/app.rs` to respect the user's configured default action for both monetary and non-monetary results. This includes updating item generation and modifier handling for conversions and currency listings. [[1]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R26-R46) [[2]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R91-R92) [[3]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L78-R101) [[4]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L101-R136) [[5]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L117-R164) [[6]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R175) [[7]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L162-R306) [[8]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L239-R319) [[9]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R347-R374)

* Updated the workflow's configuration UI and internal settings handling to pass the new preferences through to the conversion logic. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR3-R10) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL68-R80)

**Documentation updates:**

* Updated `README.md` and `CHANGELOG.md` to document the new default action settings and revised shortcut behavior. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R33) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46-R49) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3)

These changes make the workflow more flexible and user-friendly by allowing users to tailor the default behavior of conversion results to their preferences.