### PR TITLE
feat: improve Imperial and US customary unit support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1-dev
+
+- [FEAT] add an Imperial/US customary preference for ambiguous legacy unit shorthand
+
 ## 1.3.0
 
 - [FEAT] add separate configurable default actions for monetary and non-monetary results, with Command-Return performing the alternate website or clipboard action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.3.1-dev
 
+- [FEAT] add explicit UK/US customary aliases for cross-system unit conversions
 - [FEAT] add an Imperial/US customary preference for ambiguous legacy unit shorthand
 
 ## 1.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "alfred_convert"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "alfred_workflow_rs",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alfred_convert"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Convert currencies and physical units with Alfred."

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ DKK, EUR, GBP, HKD, HUF, IDR, ILS, INR, ISK, JPY, KRW, MXN, MYR, NOK, NZD, PHP, 
 
 The Workflow Configuration defaults ambiguous historical shorthand to Imperial (UK) units. Choose US customary to use US definitions for bare `gal`, `pt`, `fl.oz`/`floz`, `tbsp.`, `tsp.`, and `mpg`. Explicit `us.gal`, `us.pt`, `us.fl.oz`, `us.floz`, and `us.mpg` aliases always use US customary units, while native Numbat names such as `gallon`, `tablespoon`, and `fluidounce` remain explicit. `cup` is always US customary.
 
+To convert between systems explicitly, use the lowercase `uk_`/`us_` aliases in the three- or four-token form. Short and long spellings are available as `uk_gal`/`uk_gallon`, `uk_qt`/`uk_quart`, `uk_pt`/`uk_pint`, `uk_gi`/`uk_gill`, `uk_floz`/`uk_fluid_ounce`, `uk_fldr`/`uk_fluid_drachm`, `uk_tbsp`/`uk_tablespoon`, `uk_tsp`/`uk_teaspoon`, and `uk_mpg`/`uk_miles_per_gallon`, with corresponding `us_` forms (the US long fluid-dram spelling is `us_fluid_dram`). For example, `conv 1 uk_floz to us_floz` returns `1 UK fl oz = 0.961 US fl oz`. Explicit aliases ignore the customary-unit preference in both source and target positions. `uk_cup`, bushel, and hogshead aliases are not defined because this workflow has no like-for-like pair for them.
+
 ### Default actions
 
 The Workflow Configuration provides separate Default monetary action and Default non-monetary action preferences. `Open website` remains the default for both; choose `Copy to clipboard` to copy only the converted value instead. <kbd>cmd+return</kbd> always performs the alternate action.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ In order to set a default currency, you can set it in the Workflow Configuration
 Valid values are the [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency codes: AUD, BRL, CAD, CHF, CNY, CZK, 
 DKK, EUR, GBP, HKD, HUF, IDR, ILS, INR, ISK, JPY, KRW, MXN, MYR, NOK, NZD, PHP, PLN, RON, RUB, SEK, SGD, THB, TRY, USD, ZAR.
 
+### Default customary units
+
+The Workflow Configuration defaults ambiguous historical shorthand to Imperial (UK) units. Choose US customary to use US definitions for bare `gal`, `pt`, `fl.oz`/`floz`, `tbsp.`, `tsp.`, and `mpg`. Explicit `us.gal`, `us.pt`, `us.fl.oz`, `us.floz`, and `us.mpg` aliases always use US customary units, while native Numbat names such as `gallon`, `tablespoon`, and `fluidounce` remain explicit. `cup` is always US customary.
+
 ### Default actions
 
 The Workflow Configuration provides separate Default monetary action and Default non-monetary action preferences. `Open website` remains the default for both; choose `Copy to clipboard` to copy only the converted value instead. <kbd>cmd+return</kbd> always performs the alternate action.

--- a/info.plist
+++ b/info.plist
@@ -336,7 +336,9 @@ Heavily inspired by [deanishe/alfred-convert](https://github.com/deanishe/alfred
       - &lt;kbd&gt;option+return&lt;/kbd&gt; (⌥↵) shows the inverse rate and copies it when Copy to clipboard is the default.
       - Quick Look (`⌘Y`) always opens the Xe chart.
 - `conv units` - View a list of all the supported physical units
-    - When selecting a certain unit and pressing &lt;kbd&gt;return&lt;/kbd&gt; (↵) that unit's symbol will get copied to the clipboard.</string>
+    - When selecting a certain unit and pressing &lt;kbd&gt;return&lt;/kbd&gt; (↵) that unit's symbol will get copied to the clipboard.
+
+The Default customary units preference selects Imperial (UK) or US customary definitions for ambiguous historical shorthand: `gal`, `pt`, `fl.oz`/`floz`, `tbsp.`, `tsp.`, and `mpg`. Explicit `us.*` aliases and native Numbat unit names override the preference; `cup` remains US customary.</string>
 	<key>uidata</key>
 	<dict>
 		<key>1BBB07BA-11B1-4386-AB63-A9CB78D9A1A9</key>
@@ -525,6 +527,32 @@ Heavily inspired by [deanishe/alfred-convert](https://github.com/deanishe/alfred
 			<string>popupbutton</string>
 			<key>variable</key>
 			<string>default_currency</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>imperial</string>
+				<key>pairs</key>
+				<array>
+					<array>
+						<string>Imperial (UK)</string>
+						<string>imperial</string>
+					</array>
+					<array>
+						<string>US customary</string>
+						<string>us_customary</string>
+					</array>
+				</array>
+			</dict>
+			<key>description</key>
+			<string>Choose the default system for ambiguous unit shorthand.</string>
+			<key>label</key>
+			<string>Default customary units</string>
+			<key>type</key>
+			<string>popupbutton</string>
+			<key>variable</key>
+			<string>default_customary_system</string>
 		</dict>
 		<dict>
 			<key>config</key>

--- a/info.plist
+++ b/info.plist
@@ -338,7 +338,7 @@ Heavily inspired by [deanishe/alfred-convert](https://github.com/deanishe/alfred
 - `conv units` - View a list of all the supported physical units
     - When selecting a certain unit and pressing &lt;kbd&gt;return&lt;/kbd&gt; (↵) that unit's symbol will get copied to the clipboard.
 
-The Default customary units preference selects Imperial (UK) or US customary definitions for ambiguous historical shorthand: `gal`, `pt`, `fl.oz`/`floz`, `tbsp.`, `tsp.`, and `mpg`. Explicit `us.*` aliases and native Numbat unit names override the preference; `cup` remains US customary.</string>
+The Default customary units preference selects Imperial (UK) or US customary definitions for ambiguous historical shorthand: `gal`, `pt`, `fl.oz`/`floz`, `tbsp.`, `tsp.`, and `mpg`. Explicit `us.*` aliases and native Numbat unit names override the preference; `cup` remains US customary. For cross-system conversions, use lowercase `uk_`/`us_` aliases (short or long forms) for gallons, quarts, pints, gills, fluid ounces, fluid drachms/drams, tablespoons, teaspoons, and miles per gallon. For example, `conv 1 uk_floz to us_floz` gives `1 UK fl oz = 0.961 US fl oz`; these explicit aliases ignore the preference.</string>
 	<key>uidata</key>
 	<dict>
 		<key>1BBB07BA-11B1-4386-AB63-A9CB78D9A1A9</key>

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,9 @@ use url::Url;
 
 use crate::currency::{CURRENCIES, Currency, ExchangeRates, divide_like_dart};
 use crate::format::{format_decimal, parse_decimal};
-use crate::units::{UnitEngine, UnitListing, legacy_conversion};
+use crate::units::{
+    CustomarySystem, UnitEngine, UnitListing, legacy_conversion_with_customary_system,
+};
 
 const MONTHS: [&str; 12] = [
     "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
@@ -93,6 +95,32 @@ pub fn conversion_item(
     rates: Option<&ExchangeRates>,
     unit_engine: &mut Option<UnitEngine>,
 ) -> Result<PendingItem> {
+    conversion_item_with_customary_system(
+        query,
+        home,
+        monetary_default_action,
+        non_monetary_default_action,
+        CustomarySystem::default(),
+        rates,
+        unit_engine,
+    )
+}
+
+/// Converts a query using the selected customary system for legacy shorthand.
+///
+/// Native Numbat expressions and explicit unit identifiers are never rewritten.
+///
+/// # Errors
+/// Returns an error only when Alfred item metadata cannot be constructed.
+pub fn conversion_item_with_customary_system(
+    query: &str,
+    home: Currency,
+    monetary_default_action: DefaultAction,
+    non_monetary_default_action: DefaultAction,
+    customary_system: CustomarySystem,
+    rates: Option<&ExchangeRates>,
+    unit_engine: &mut Option<UnitEngine>,
+) -> Result<PendingItem> {
     let parts = query.split(' ').collect::<Vec<_>>();
     if let Some(from) = parts.get(1).and_then(|part| Currency::from_code(part)) {
         if parse_decimal(parts[0]).is_none() {
@@ -112,7 +140,7 @@ pub fn conversion_item(
         Some(engine) => engine,
         slot @ None => slot.insert(UnitEngine::new()?),
     };
-    if let Some(conversion) = legacy_conversion(query) {
+    if let Some(conversion) = legacy_conversion_with_customary_system(query, customary_system) {
         return match engine.evaluate_legacy(conversion) {
             Ok(evaluation) => {
                 let url = wolfram_url(&format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,14 +6,14 @@ use std::process::ExitCode;
 use std::time::Duration;
 
 use alfred_convert::app::{
-    DefaultAction, PendingItem, conversion_item, currency_items, invalid_item, placeholder_item,
-    unit_items,
+    DefaultAction, PendingItem, conversion_item_with_customary_system, currency_items,
+    invalid_item, placeholder_item, unit_items,
 };
 use alfred_convert::cli::Cli;
 use alfred_convert::currency::{Currency, EcbClient, ExchangeRateCache};
 use alfred_convert::format::parse_decimal;
 use alfred_convert::services::emoji_image_cache::EmojiImageCache;
-use alfred_convert::units::UnitEngine;
+use alfred_convert::units::{CustomarySystem, UnitEngine};
 use alfred_workflow_rs::{Icon, Item, RenderOptions, Updater, UserConfiguration, Workflow};
 use anyhow::{Result, anyhow};
 use jiff::Timestamp;
@@ -107,11 +107,12 @@ fn populate_workflow(workflow: &mut Workflow, cli: &Cli) -> Result<()> {
         None
     };
     let mut unit_engine = None;
-    let item = conversion_item(
+    let item = conversion_item_with_customary_system(
         &query,
         settings.home_currency,
         settings.default_monetary_action,
         settings.default_non_monetary_action,
+        settings.customary_system,
         rates.as_ref(),
         &mut unit_engine,
     )?;
@@ -188,6 +189,7 @@ struct WorkflowSettings {
     home_currency: Currency,
     default_monetary_action: DefaultAction,
     default_non_monetary_action: DefaultAction,
+    customary_system: CustomarySystem,
 }
 
 fn workflow_settings(workflow: &Workflow, directory: &Path) -> Result<WorkflowSettings> {
@@ -215,10 +217,15 @@ fn workflow_settings_from_defaults(
         Some(UserConfiguration::Select(configuration)) => Some(configuration.config.value.as_str()),
         _ => None,
     };
+    let configured_customary_system = match defaults.get("default_customary_system") {
+        Some(UserConfiguration::Select(configuration)) => Some(configuration.config.value.as_str()),
+        _ => None,
+    };
     Ok(WorkflowSettings {
         home_currency,
         default_monetary_action: DefaultAction::from_preference(configured_monetary_action),
         default_non_monetary_action: DefaultAction::from_preference(configured_non_monetary_action),
+        customary_system: CustomarySystem::from_preference(configured_customary_system),
     })
 }
 

--- a/src/tests/app.rs
+++ b/src/tests/app.rs
@@ -525,6 +525,72 @@ fn customary_system_should_change_legacy_fluid_ounce_rendering() -> anyhow::Resu
 }
 
 #[test]
+fn explicit_customary_aliases_should_keep_labels_and_actions() -> anyhow::Result<()> {
+    let home = currency("USD")?;
+    let expected_url = "https://www.wolframalpha.com/input?i=1.0+UK+fl+oz+to+US+fl+oz";
+    for customary_system in [CustomarySystem::Imperial, CustomarySystem::UsCustomary] {
+        let mut engine = None;
+        let website_item = conversion_item_with_customary_system(
+            "1 uk_floz to us_floz",
+            home,
+            DefaultAction::OpenWebsite,
+            DefaultAction::OpenWebsite,
+            customary_system,
+            None,
+            &mut engine,
+        )?
+        .into_item(None);
+        let website_command = website_item
+            .modifiers()
+            .and_then(|modifiers| modifiers.get("cmd"));
+        assert_eq!(
+            (
+                website_item.title(),
+                website_item.subtitle(),
+                website_item.arg(),
+                website_item.quick_look_url(),
+                website_command.and_then(alfred_workflow_rs::Modifier::arg),
+            ),
+            (
+                "1 UK fl oz = 0.961 US fl oz",
+                Some("Based on the fact that 1 UK fl oz = 0.961 US fl oz"),
+                Some(expected_url),
+                Some(expected_url),
+                Some("0.961 US fl oz"),
+            )
+        );
+
+        let mut engine = None;
+        let copy_item = conversion_item_with_customary_system(
+            "1 uk_floz to us_floz",
+            home,
+            DefaultAction::OpenWebsite,
+            DefaultAction::CopyToClipboard,
+            customary_system,
+            None,
+            &mut engine,
+        )?
+        .into_item(None);
+        let copy_command = copy_item
+            .modifiers()
+            .and_then(|modifiers| modifiers.get("cmd"));
+        assert_eq!(
+            (
+                copy_item.arg(),
+                copy_item.quick_look_url(),
+                copy_command.and_then(alfred_workflow_rs::Modifier::arg),
+            ),
+            (
+                Some("0.961 US fl oz"),
+                Some(expected_url),
+                Some(expected_url),
+            )
+        );
+    }
+    Ok(())
+}
+
+#[test]
 fn invalid_unit_expression_should_not_receive_result_actions() -> anyhow::Result<()> {
     let home = currency("USD")?;
     let mut engine = None;

--- a/src/tests/app.rs
+++ b/src/tests/app.rs
@@ -1,8 +1,9 @@
 use crate::app::{
-    DefaultAction, conversion_item, currency_items, invalid_item, placeholder_item, unit_items,
+    DefaultAction, conversion_item, conversion_item_with_customary_system, currency_items,
+    invalid_item, placeholder_item, unit_items,
 };
 use crate::currency::{Currency, ExchangeRates};
-use crate::units::UnitListing;
+use crate::units::{CustomarySystem, UnitListing};
 use jiff::Timestamp;
 use rust_decimal::Decimal;
 
@@ -445,6 +446,81 @@ fn legacy_unit_conversion_should_copy_only_the_value_by_default() -> anyhow::Res
             Some("Open conversion details on WolframAlpha.com"),
         )
     );
+    Ok(())
+}
+
+#[test]
+fn customary_system_should_change_legacy_fluid_ounce_rendering() -> anyhow::Result<()> {
+    let home = currency("USD")?;
+    for (system, expected_title, expected_subtitle, expected_value, expected_url) in [
+        (
+            CustomarySystem::Imperial,
+            "1 imp fl oz = 28.413 ml",
+            "Based on the fact that 1 imp fl oz = 28.413 ml",
+            "28.413 ml",
+            "https://www.wolframalpha.com/input?i=1.0+imp+fl+oz+to+ml",
+        ),
+        (
+            CustomarySystem::UsCustomary,
+            "1 US fl oz = 29.574 ml",
+            "Based on the fact that 1 US fl oz = 29.574 ml",
+            "29.574 ml",
+            "https://www.wolframalpha.com/input?i=1.0+US+fl+oz+to+ml",
+        ),
+    ] {
+        let mut engine = None;
+        let item = conversion_item_with_customary_system(
+            "1 floz ml",
+            home,
+            DefaultAction::OpenWebsite,
+            DefaultAction::OpenWebsite,
+            system,
+            None,
+            &mut engine,
+        )?
+        .into_item(None);
+        assert_eq!(
+            (
+                item.title(),
+                item.subtitle(),
+                item.arg(),
+                item.quick_look_url()
+            ),
+            (
+                expected_title,
+                Some(expected_subtitle),
+                Some(expected_url),
+                Some(expected_url),
+            )
+        );
+
+        let mut engine = None;
+        let copy_item = conversion_item_with_customary_system(
+            "1 floz ml",
+            home,
+            DefaultAction::OpenWebsite,
+            DefaultAction::CopyToClipboard,
+            system,
+            None,
+            &mut engine,
+        )?
+        .into_item(None);
+        let command = copy_item
+            .modifiers()
+            .and_then(|modifiers| modifiers.get("cmd"));
+        assert_eq!(
+            (
+                copy_item.arg(),
+                command.and_then(alfred_workflow_rs::Modifier::arg),
+                command.and_then(alfred_workflow_rs::Modifier::subtitle),
+            ),
+            (
+                Some(expected_value),
+                Some(expected_url),
+                Some("Open conversion details on WolframAlpha.com"),
+            )
+        );
+    }
     Ok(())
 }
 

--- a/src/tests/main.rs
+++ b/src/tests/main.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use alfred_convert::app::DefaultAction;
+use alfred_convert::units::CustomarySystem;
 use alfred_workflow_rs::{
     AutomaticCache, CheckBoxConfiguration, CheckBoxUserConfiguration, SelectConfiguration,
     SelectUserConfiguration, UserConfiguration, Workflow,
@@ -123,6 +124,7 @@ fn workflow_settings_should_load_all_select_preferences() -> anyhow::Result<()> 
         select_configuration("default_currency", "EUR"),
         select_configuration("default_monetary_action", "copy_to_clipboard"),
         select_configuration("default_non_monetary_action", "open_website"),
+        select_configuration("default_customary_system", "us_customary"),
     ]);
     let settings = workflow_settings_from_defaults(&defaults)?;
     assert_eq!(
@@ -130,11 +132,13 @@ fn workflow_settings_should_load_all_select_preferences() -> anyhow::Result<()> 
             settings.home_currency.code(),
             settings.default_monetary_action,
             settings.default_non_monetary_action,
+            settings.customary_system,
         ),
         (
             "EUR",
             DefaultAction::CopyToClipboard,
             DefaultAction::OpenWebsite,
+            CustomarySystem::UsCustomary,
         )
     );
     Ok(())
@@ -165,8 +169,13 @@ fn workflow_settings_should_fall_back_for_wrong_action_configuration_type() -> a
         (
             settings.default_monetary_action,
             settings.default_non_monetary_action,
+            settings.customary_system,
         ),
-        (DefaultAction::OpenWebsite, DefaultAction::CopyToClipboard,)
+        (
+            DefaultAction::OpenWebsite,
+            DefaultAction::CopyToClipboard,
+            CustomarySystem::Imperial,
+        )
     );
     Ok(())
 }
@@ -183,9 +192,47 @@ fn workflow_settings_should_ignore_obsolete_and_unknown_action_values() -> anyho
         (
             settings.default_monetary_action,
             settings.default_non_monetary_action,
+            settings.customary_system,
         ),
-        (DefaultAction::OpenWebsite, DefaultAction::OpenWebsite)
+        (
+            DefaultAction::OpenWebsite,
+            DefaultAction::OpenWebsite,
+            CustomarySystem::Imperial,
+        )
     );
+    Ok(())
+}
+
+#[test]
+fn workflow_settings_should_fall_back_for_invalid_customary_system_preferences()
+-> anyhow::Result<()> {
+    for configuration in [
+        UserConfiguration::CheckBox(CheckBoxUserConfiguration {
+            variable: "default_customary_system".to_owned(),
+            description: None,
+            label: None,
+            config: CheckBoxConfiguration {
+                default_value: true,
+                value: true,
+                required: false,
+                text: None,
+            },
+        }),
+        UserConfiguration::Select(SelectUserConfiguration {
+            variable: "default_customary_system".to_owned(),
+            description: None,
+            label: None,
+            config: SelectConfiguration {
+                default_value: "unexpected".to_owned(),
+                value: "unexpected".to_owned(),
+                pairs: Vec::new(),
+            },
+        }),
+    ] {
+        let defaults = BTreeMap::from([("default_customary_system".to_owned(), configuration)]);
+        let settings = workflow_settings_from_defaults(&defaults)?;
+        assert_eq!(settings.customary_system, CustomarySystem::Imperial);
+    }
     Ok(())
 }
 

--- a/src/tests/units.rs
+++ b/src/tests/units.rs
@@ -1,4 +1,7 @@
-use super::{LegacyConversion, UnitEngine, legacy_conversion, legacy_unit};
+use super::{
+    CustomarySystem, LegacyConversion, UnitEngine, legacy_conversion,
+    legacy_conversion_with_customary_system, legacy_unit, legacy_unit_with_customary_system,
+};
 
 const CONVERTIBLE_DART_ALIASES: &[&str] = &[
     "°",
@@ -404,6 +407,109 @@ fn compatibility_aliases_should_keep_imperial_gallon_semantics() -> anyhow::Resu
         legacy_conversion("1 gal l").ok_or_else(|| anyhow::anyhow!("legacy conversion missing"))?;
     let result = engine.evaluate_legacy(conversion)?;
     assert_eq!(result.result, "1 imp gal = 4.546 l");
+    Ok(())
+}
+
+#[test]
+fn customary_system_preference_should_default_to_imperial() {
+    assert_eq!(CustomarySystem::default(), CustomarySystem::Imperial);
+    assert_eq!(
+        CustomarySystem::from_preference(Some("imperial")),
+        CustomarySystem::Imperial
+    );
+    assert_eq!(
+        CustomarySystem::from_preference(Some("us_customary")),
+        CustomarySystem::UsCustomary
+    );
+    assert_eq!(
+        CustomarySystem::from_preference(None),
+        CustomarySystem::Imperial
+    );
+    assert_eq!(
+        CustomarySystem::from_preference(Some("unknown")),
+        CustomarySystem::Imperial
+    );
+}
+
+#[test]
+fn customary_system_should_resolve_ambiguous_aliases_in_both_positions() -> anyhow::Result<()> {
+    for alias in ["gal", "pt", "fl.oz", "floz", "tbsp.", "tsp.", "mpg"] {
+        let imperial = legacy_unit_with_customary_system(alias, CustomarySystem::Imperial)
+            .ok_or_else(|| anyhow::anyhow!("imperial alias {alias} missing"))?;
+        let us = legacy_unit_with_customary_system(alias, CustomarySystem::UsCustomary)
+            .ok_or_else(|| anyhow::anyhow!("US alias {alias} missing"))?;
+        if alias == "mpg" {
+            assert_ne!(imperial.special, us.special, "alias: {alias}");
+        } else {
+            assert_ne!(imperial.expression, us.expression, "alias: {alias}");
+        }
+
+        let companion = if alias == "mpg" { "km/l" } else { "ml" };
+        let imperial_query = format!("1 {alias} {companion}");
+        let us_query = format!("1 {companion} {alias}");
+        let imperial_conversion =
+            legacy_conversion_with_customary_system(&imperial_query, CustomarySystem::Imperial)
+                .ok_or_else(|| anyhow::anyhow!("source alias: {alias}"))?;
+        let us_conversion =
+            legacy_conversion_with_customary_system(&us_query, CustomarySystem::UsCustomary)
+                .ok_or_else(|| anyhow::anyhow!("target alias: {alias}"))?;
+        assert_eq!(imperial_conversion.from, imperial, "source alias: {alias}");
+        assert_eq!(us_conversion.to, us, "target alias: {alias}");
+    }
+    Ok(())
+}
+
+#[test]
+fn customary_system_should_preserve_explicit_us_aliases_and_native_units() -> anyhow::Result<()> {
+    for alias in ["us.gal", "us.pt", "us.fl.oz", "us.floz", "us.mpg"] {
+        let imperial = legacy_unit_with_customary_system(alias, CustomarySystem::Imperial)
+            .ok_or_else(|| anyhow::anyhow!("imperial lookup missing {alias}"))?;
+        let us = legacy_unit_with_customary_system(alias, CustomarySystem::UsCustomary)
+            .ok_or_else(|| anyhow::anyhow!("US lookup missing {alias}"))?;
+        assert_eq!(imperial, us, "explicit alias changed: {alias}");
+    }
+    let mut engine = UnitEngine::new()?;
+    assert_eq!(
+        engine.evaluate_native("1 gallon to liter")?.result,
+        "3.78541 l"
+    );
+    assert_eq!(
+        engine.evaluate_native("1 imperial_gallon to liter")?.result,
+        "4.54609 l"
+    );
+    assert_eq!(engine.evaluate_native("1 cup to mL")?.result, "236.588 ml");
+    Ok(())
+}
+
+#[test]
+fn customary_system_should_match_legacy_volume_and_mpg_coefficients() -> anyhow::Result<()> {
+    let cases = [
+        (
+            "1 floz ml",
+            "1 imp fl oz = 28.413 ml",
+            "1 US fl oz = 29.574 ml",
+        ),
+        ("1 gal l", "1 imp gal = 4.546 l", "1 US gal = 3.785 l"),
+        ("1 pt ml", "1 imp pt = 568.261 ml", "1 US pt = 473.176 ml"),
+        ("1 tbsp. ml", "1 tbsp. = 14.207 ml", "1 tbsp. = 14.787 ml"),
+        ("1 tsp. ml", "1 tsp. = 3.552 ml", "1 tsp. = 4.929 ml"),
+        ("1 mpg km/l", "1 mpg = 0.354 km/l", "1 mpg = 0.425 km/l"),
+    ];
+    for (query, expected_imperial, expected_us) in cases {
+        let mut engine = UnitEngine::new()?;
+        let imperial = legacy_conversion_with_customary_system(query, CustomarySystem::Imperial)
+            .ok_or_else(|| anyhow::anyhow!("imperial conversion missing: {query}"))?;
+        assert_eq!(
+            engine.evaluate_legacy(imperial)?.result,
+            expected_imperial,
+            "{query}"
+        );
+
+        let mut engine = UnitEngine::new()?;
+        let us = legacy_conversion_with_customary_system(query, CustomarySystem::UsCustomary)
+            .ok_or_else(|| anyhow::anyhow!("US conversion missing: {query}"))?;
+        assert_eq!(engine.evaluate_legacy(us)?.result, expected_us, "{query}");
+    }
     Ok(())
 }
 

--- a/src/tests/units.rs
+++ b/src/tests/units.rs
@@ -1,3 +1,4 @@
+use super::normalize::{FuelUnit, SpecialUnit};
 use super::{
     CustomarySystem, LegacyConversion, UnitEngine, legacy_conversion,
     legacy_conversion_with_customary_system, legacy_unit, legacy_unit_with_customary_system,
@@ -509,6 +510,214 @@ fn customary_system_should_match_legacy_volume_and_mpg_coefficients() -> anyhow:
         let us = legacy_conversion_with_customary_system(query, CustomarySystem::UsCustomary)
             .ok_or_else(|| anyhow::anyhow!("US conversion missing: {query}"))?;
         assert_eq!(engine.evaluate_legacy(us)?.result, expected_us, "{query}");
+    }
+    Ok(())
+}
+
+fn assert_explicit_ordinary_aliases(
+    aliases: &[(&[&str], &str, &str)],
+    customary_system: CustomarySystem,
+) -> anyhow::Result<()> {
+    for (alias_names, expression, symbol) in aliases {
+        for alias in *alias_names {
+            let unit = legacy_unit_with_customary_system(alias, customary_system)
+                .ok_or_else(|| anyhow::anyhow!("alias {alias} is missing"))?;
+            assert_eq!(
+                (unit.expression, unit.symbol),
+                (*expression, *symbol),
+                "{alias}"
+            );
+
+            let source = format!("1 {alias} ml");
+            let source_conversion =
+                legacy_conversion_with_customary_system(&source, customary_system)
+                    .ok_or_else(|| anyhow::anyhow!("source alias {alias} is missing"))?;
+            assert_eq!(source_conversion.from, unit, "source alias {alias}");
+
+            let target = format!("1 ml {alias}");
+            let target_conversion =
+                legacy_conversion_with_customary_system(&target, customary_system)
+                    .ok_or_else(|| anyhow::anyhow!("target alias {alias} is missing"))?;
+            assert_eq!(target_conversion.to, unit, "target alias {alias}");
+        }
+    }
+    Ok(())
+}
+
+fn assert_explicit_fuel_aliases(customary_system: CustomarySystem) -> anyhow::Result<()> {
+    for (alias, unit) in [
+        ("uk_mpg", FuelUnit::MilesPerImperialGallon),
+        ("uk_miles_per_gallon", FuelUnit::MilesPerImperialGallon),
+        ("us_mpg", FuelUnit::MilesPerUsGallon),
+        ("us_miles_per_gallon", FuelUnit::MilesPerUsGallon),
+    ] {
+        let resolved = legacy_unit_with_customary_system(alias, customary_system)
+            .ok_or_else(|| anyhow::anyhow!("fuel alias {alias} is missing"))?;
+        assert_eq!(
+            resolved.symbol,
+            if alias.starts_with("uk_") {
+                "UK mpg"
+            } else {
+                "US mpg"
+            }
+        );
+        assert_eq!(resolved.special, SpecialUnit::Fuel(unit), "{alias}");
+
+        let source = format!("1 {alias} km/l");
+        let source_conversion = legacy_conversion_with_customary_system(&source, customary_system)
+            .ok_or_else(|| anyhow::anyhow!("source fuel alias {alias} is missing"))?;
+        assert_eq!(source_conversion.from, resolved, "source alias {alias}");
+
+        let target = format!("1 km/l {alias}");
+        let target_conversion = legacy_conversion_with_customary_system(&target, customary_system)
+            .ok_or_else(|| anyhow::anyhow!("target fuel alias {alias} is missing"))?;
+        assert_eq!(target_conversion.to, resolved, "target alias {alias}");
+    }
+    Ok(())
+}
+
+#[test]
+fn explicit_customary_aliases_should_resolve_independently_of_preference() -> anyhow::Result<()> {
+    let ordinary_aliases = [
+        (
+            ["uk_gal", "uk_gallon"].as_slice(),
+            "imperial_gallon",
+            "UK gal",
+        ),
+        (["us_gal", "us_gallon"].as_slice(), "gallon", "US gal"),
+        (["uk_qt", "uk_quart"].as_slice(), "imperial_quart", "UK qt"),
+        (["us_qt", "us_quart"].as_slice(), "gallon / 4", "US qt"),
+        (["uk_pt", "uk_pint"].as_slice(), "imperial_pint", "UK pt"),
+        (["us_pt", "us_pint"].as_slice(), "pint", "US pt"),
+        (["uk_gi", "uk_gill"].as_slice(), "imperial_gill", "UK gi"),
+        (["us_gi", "us_gill"].as_slice(), "gallon / 32", "US gi"),
+        (
+            ["uk_floz", "uk_fluid_ounce"].as_slice(),
+            "imperial_fluidounce",
+            "UK fl oz",
+        ),
+        (
+            ["us_floz", "us_fluid_ounce"].as_slice(),
+            "fluidounce",
+            "US fl oz",
+        ),
+        (
+            ["uk_fldr", "uk_fluid_drachm"].as_slice(),
+            "imperial_fluid_drachm",
+            "UK fl dr",
+        ),
+        (
+            ["us_fldr", "us_fluid_dram"].as_slice(),
+            "fluidounce / 8",
+            "US fl dr",
+        ),
+        (
+            ["uk_tbsp", "uk_tablespoon"].as_slice(),
+            "imperial_tablespoon",
+            "UK tbsp",
+        ),
+        (
+            ["us_tbsp", "us_tablespoon"].as_slice(),
+            "tablespoon",
+            "US tbsp",
+        ),
+        (
+            ["uk_tsp", "uk_teaspoon"].as_slice(),
+            "imperial_teaspoon",
+            "UK tsp",
+        ),
+        (["us_tsp", "us_teaspoon"].as_slice(), "teaspoon", "US tsp"),
+    ];
+    for customary_system in [CustomarySystem::Imperial, CustomarySystem::UsCustomary] {
+        assert_explicit_ordinary_aliases(&ordinary_aliases, customary_system)?;
+        assert_explicit_fuel_aliases(customary_system)?;
+    }
+    assert!(
+        legacy_conversion_with_customary_system("1 uk_cup us_cup", CustomarySystem::Imperial)
+            .is_none()
+    );
+    Ok(())
+}
+
+#[test]
+fn explicit_customary_pairs_should_render_the_same_under_both_preferences() -> anyhow::Result<()> {
+    let cases = [
+        (
+            "1 uk_gal to us_gal",
+            "1 UK gal = 1.201 US gal",
+            "1 us_gal to uk_gal",
+            "1 US gal = 0.833 UK gal",
+        ),
+        (
+            "1 uk_qt to us_qt",
+            "1 UK qt = 1.201 US qt",
+            "1 us_qt to uk_qt",
+            "1 US qt = 0.833 UK qt",
+        ),
+        (
+            "1 uk_pt to us_pt",
+            "1 UK pt = 1.201 US pt",
+            "1 us_pt to uk_pt",
+            "1 US pt = 0.833 UK pt",
+        ),
+        (
+            "1 uk_gi to us_gi",
+            "1 UK gi = 1.201 US gi",
+            "1 us_gi to uk_gi",
+            "1 US gi = 0.833 UK gi",
+        ),
+        (
+            "1 uk_floz to us_floz",
+            "1 UK fl oz = 0.961 US fl oz",
+            "1 us_floz to uk_floz",
+            "1 US fl oz = 1.041 UK fl oz",
+        ),
+        (
+            "1 uk_fldr to us_fldr",
+            "1 UK fl dr = 0.961 US fl dr",
+            "1 us_fldr to uk_fldr",
+            "1 US fl dr = 1.041 UK fl dr",
+        ),
+        (
+            "1 uk_tbsp to us_tbsp",
+            "1 UK tbsp = 0.961 US tbsp",
+            "1 us_tbsp to uk_tbsp",
+            "1 US tbsp = 1.041 UK tbsp",
+        ),
+        (
+            "1 uk_tsp to us_tsp",
+            "1 UK tsp = 0.721 US tsp",
+            "1 us_tsp to uk_tsp",
+            "1 US tsp = 1.388 UK tsp",
+        ),
+        (
+            "1 uk_mpg to us_mpg",
+            "1 UK mpg = 0.833 US mpg",
+            "1 us_mpg to uk_mpg",
+            "1 US mpg = 1.201 UK mpg",
+        ),
+    ];
+    for customary_system in [CustomarySystem::Imperial, CustomarySystem::UsCustomary] {
+        let mut engine = UnitEngine::new()?;
+        for (forward, expected_forward, reverse, expected_reverse) in cases {
+            let forward_conversion =
+                legacy_conversion_with_customary_system(forward, customary_system)
+                    .ok_or_else(|| anyhow::anyhow!("pair should parse: {forward}"))?;
+            assert_eq!(
+                engine.evaluate_legacy(forward_conversion)?.result,
+                expected_forward,
+                "{forward}"
+            );
+
+            let reverse_conversion =
+                legacy_conversion_with_customary_system(reverse, customary_system)
+                    .ok_or_else(|| anyhow::anyhow!("pair should parse: {reverse}"))?;
+            assert_eq!(
+                engine.evaluate_legacy(reverse_conversion)?.result,
+                expected_reverse,
+                "{reverse}"
+            );
+        }
     }
     Ok(())
 }

--- a/src/units/engine.rs
+++ b/src/units/engine.rs
@@ -164,7 +164,7 @@ impl UnitEngine {
         to: super::normalize::LegacyUnit,
     ) -> Result<Decimal> {
         let expression = legacy_expression(amount, from, to)?;
-        match self.evaluate(&expression)? {
+        let value = match self.evaluate(&expression)? {
             Value::Quantity(quantity) => legacy_decimal(quantity.unsafe_value().to_f64())
                 .ok_or_else(|| anyhow!("Numbat returned a non-finite legacy result")),
             value => {
@@ -172,7 +172,19 @@ impl UnitEngine {
                 parse_decimal(&rendered)
                     .ok_or_else(|| anyhow!("Numbat returned {rendered} instead of a quantity"))
             }
-        }
+        }?;
+        value
+            .checked_mul(legacy_target_scale(to.expression))
+            .ok_or_else(|| anyhow!("Numbat returned an out-of-range legacy result"))
+    }
+}
+
+fn legacy_target_scale(expression: &str) -> Decimal {
+    match expression {
+        "gallon / 4" => Decimal::from(4),
+        "gallon / 32" => Decimal::from(32),
+        "fluidounce / 8" => Decimal::from(8),
+        _ => Decimal::ONE,
     }
 }
 

--- a/src/units/mod.rs
+++ b/src/units/mod.rs
@@ -4,7 +4,10 @@ mod engine;
 mod normalize;
 
 pub use engine::{UnitEngine, UnitEvaluation, UnitListing};
-pub use normalize::{LegacyConversion, legacy_conversion, legacy_unit};
+pub use normalize::{
+    CustomarySystem, LegacyConversion, legacy_conversion, legacy_conversion_with_customary_system,
+    legacy_unit, legacy_unit_with_customary_system,
+};
 
 #[cfg(test)]
 #[path = "../tests/units.rs"]

--- a/src/units/normalize.rs
+++ b/src/units/normalize.rs
@@ -204,6 +204,8 @@ pub fn legacy_unit_with_customary_system(
         "km/l" => fuel("km/l", FuelUnit::KilometersPerLiter),
         "l/100km" => fuel("l/100km", FuelUnit::LitersPer100Kilometers),
         "us.mpg" => fuel("mpg", FuelUnit::MilesPerUsGallon),
+        "uk_mpg" | "uk_miles_per_gallon" => fuel("UK mpg", FuelUnit::MilesPerImperialGallon),
+        "us_mpg" | "us_miles_per_gallon" => fuel("US mpg", FuelUnit::MilesPerUsGallon),
         "mpg" => match customary_system {
             CustomarySystem::Imperial => fuel("mpg", FuelUnit::MilesPerImperialGallon),
             CustomarySystem::UsCustomary => fuel("mpg", FuelUnit::MilesPerUsGallon),
@@ -306,17 +308,25 @@ pub fn legacy_unit_with_customary_system(
             CustomarySystem::Imperial => ordinary("imperial_gallon", "imp gal", "Volume", "🧪"),
             CustomarySystem::UsCustomary => ordinary("gallon", "US gal", "Volume", "🧪"),
         },
-        "us.gal" => ordinary("gallon", "US gal", "Volume", "🧪"),
+        "uk_gal" | "uk_gallon" => ordinary("imperial_gallon", "UK gal", "Volume", "🧪"),
+        "us.gal" | "us_gal" | "us_gallon" => ordinary("gallon", "US gal", "Volume", "🧪"),
         "pt" => match customary_system {
             CustomarySystem::Imperial => ordinary("imperial_pint", "imp pt", "Volume", "🧪"),
             CustomarySystem::UsCustomary => ordinary("pint", "US pt", "Volume", "🧪"),
         },
-        "us.pt" => ordinary("pint", "US pt", "Volume", "🧪"),
+        "uk_qt" | "uk_quart" => ordinary("imperial_quart", "UK qt", "Volume", "🧪"),
+        "us_qt" | "us_quart" => ordinary("gallon / 4", "US qt", "Volume", "🧪"),
+        "uk_pt" | "uk_pint" => ordinary("imperial_pint", "UK pt", "Volume", "🧪"),
+        "us.pt" | "us_pt" | "us_pint" => ordinary("pint", "US pt", "Volume", "🧪"),
+        "uk_gi" | "uk_gill" => ordinary("imperial_gill", "UK gi", "Volume", "🧪"),
+        "us_gi" | "us_gill" => ordinary("gallon / 32", "US gi", "Volume", "🧪"),
         "ml" => ordinary("mL", "ml", "Volume", "🧪"),
         "tbsp." => match customary_system {
             CustomarySystem::Imperial => ordinary("imperial_tablespoon", "tbsp.", "Volume", "🧪"),
             CustomarySystem::UsCustomary => ordinary("tablespoon", "tbsp.", "Volume", "🧪"),
         },
+        "uk_tbsp" | "uk_tablespoon" => ordinary("imperial_tablespoon", "UK tbsp", "Volume", "🧪"),
+        "us_tbsp" | "us_tablespoon" => ordinary("tablespoon", "US tbsp", "Volume", "🧪"),
         "cup" => ordinary("cup", "cup", "Volume", "🧪"),
         "cm3" => ordinary("cm^3", "cm³", "Volume", "🧪"),
         "ft3" => ordinary("ft^3", "ft³", "Volume", "🧪"),
@@ -328,7 +338,14 @@ pub fn legacy_unit_with_customary_system(
             }
             CustomarySystem::UsCustomary => ordinary("fluidounce", "US fl oz", "Volume", "🧪"),
         },
-        "us.fl.oz" | "us.floz" => ordinary("fluidounce", "US fl oz", "Volume", "🧪"),
+        "uk_floz" | "uk_fluid_ounce" => ordinary("imperial_fluidounce", "UK fl oz", "Volume", "🧪"),
+        "us.fl.oz" | "us.floz" | "us_floz" | "us_fluid_ounce" => {
+            ordinary("fluidounce", "US fl oz", "Volume", "🧪")
+        }
+        "uk_fldr" | "uk_fluid_drachm" => {
+            ordinary("imperial_fluid_drachm", "UK fl dr", "Volume", "🧪")
+        }
+        "us_fldr" | "us_fluid_dram" => ordinary("fluidounce / 8", "US fl dr", "Volume", "🧪"),
         "US. liq. gi" => ordinary("gallon / 32", "US. liq. gi", "Volume", "🧪"),
         "US. liq. qt" => ordinary("gallon / 4", "US. liq. qt", "Volume", "🧪"),
         "fl" => ordinary("femtoliter", "fl", "Volume", "🧪"),
@@ -341,6 +358,8 @@ pub fn legacy_unit_with_customary_system(
             CustomarySystem::Imperial => ordinary("imperial_teaspoon", "tsp.", "Volume", "🧪"),
             CustomarySystem::UsCustomary => ordinary("teaspoon", "tsp.", "Volume", "🧪"),
         },
+        "uk_tsp" | "uk_teaspoon" => ordinary("imperial_teaspoon", "UK tsp", "Volume", "🧪"),
+        "us_tsp" | "us_teaspoon" => ordinary("teaspoon", "US tsp", "Volume", "🧪"),
         _ => return None,
     })
 }

--- a/src/units/normalize.rs
+++ b/src/units/normalize.rs
@@ -10,6 +10,27 @@ pub struct LegacyUnit {
     pub special: SpecialUnit,
 }
 
+/// Selects which customary system ambiguous historical shorthand uses.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum CustomarySystem {
+    /// Use UK/Imperial definitions.
+    #[default]
+    Imperial,
+    /// Use US customary definitions.
+    UsCustomary,
+}
+
+impl CustomarySystem {
+    /// Parses the Alfred preference, defaulting to Imperial for unknown values.
+    #[must_use]
+    pub fn from_preference(value: Option<&str>) -> Self {
+        match value {
+            Some("us_customary") => Self::UsCustomary,
+            _ => Self::Imperial,
+        }
+    }
+}
+
 /// Legacy conversions that need an affine or reciprocal Numbat function.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SpecialUnit {
@@ -51,6 +72,15 @@ pub struct LegacyConversion<'a> {
 /// Recognizes only the Dart workflow's exact three/four-token shorthand.
 #[must_use]
 pub fn legacy_conversion(query: &str) -> Option<LegacyConversion<'_>> {
+    legacy_conversion_with_customary_system(query, CustomarySystem::default())
+}
+
+/// Recognizes historical shorthand using the selected customary system.
+#[must_use]
+pub fn legacy_conversion_with_customary_system(
+    query: &str,
+    customary_system: CustomarySystem,
+) -> Option<LegacyConversion<'_>> {
     let parts = query.split(' ').collect::<Vec<_>>();
     let (amount, from, to) = match parts.as_slice() {
         [amount, from, to] => (*amount, *from, *to),
@@ -62,8 +92,8 @@ pub fn legacy_conversion(query: &str) -> Option<LegacyConversion<'_>> {
     parse_decimal(amount)?;
     Some(LegacyConversion {
         amount,
-        from: legacy_unit(from)?,
-        to: legacy_unit(to)?,
+        from: legacy_unit_with_customary_system(from, customary_system)?,
+        to: legacy_unit_with_customary_system(to, customary_system)?,
     })
 }
 
@@ -71,6 +101,16 @@ pub fn legacy_conversion(query: &str) -> Option<LegacyConversion<'_>> {
 #[must_use]
 #[allow(clippy::too_many_lines)]
 pub fn legacy_unit(alias: &str) -> Option<LegacyUnit> {
+    legacy_unit_with_customary_system(alias, CustomarySystem::default())
+}
+
+/// Finds metadata for a historical alias using the selected customary system.
+#[must_use]
+#[allow(clippy::too_many_lines)]
+pub fn legacy_unit_with_customary_system(
+    alias: &str,
+    customary_system: CustomarySystem,
+) -> Option<LegacyUnit> {
     let ordinary = |expression, symbol, dimension, emoji| LegacyUnit {
         expression,
         symbol,
@@ -164,7 +204,10 @@ pub fn legacy_unit(alias: &str) -> Option<LegacyUnit> {
         "km/l" => fuel("km/l", FuelUnit::KilometersPerLiter),
         "l/100km" => fuel("l/100km", FuelUnit::LitersPer100Kilometers),
         "us.mpg" => fuel("mpg", FuelUnit::MilesPerUsGallon),
-        "mpg" => fuel("mpg", FuelUnit::MilesPerImperialGallon),
+        "mpg" => match customary_system {
+            CustomarySystem::Imperial => fuel("mpg", FuelUnit::MilesPerImperialGallon),
+            CustomarySystem::UsCustomary => fuel("mpg", FuelUnit::MilesPerUsGallon),
+        },
 
         "lx" => ordinary("lux", "lx", "Illuminance", "💡"),
         "fc" => ordinary("footcandle", "fc", "Illuminance", "💡"),
@@ -259,18 +302,32 @@ pub fn legacy_unit(alias: &str) -> Option<LegacyUnit> {
 
         "m3" => ordinary("m^3", "m³", "Volume", "🧪"),
         "l" | "L" => ordinary("L", "l", "Volume", "🧪"),
-        "gal" => ordinary("imperial_gallon", "imp gal", "Volume", "🧪"),
+        "gal" => match customary_system {
+            CustomarySystem::Imperial => ordinary("imperial_gallon", "imp gal", "Volume", "🧪"),
+            CustomarySystem::UsCustomary => ordinary("gallon", "US gal", "Volume", "🧪"),
+        },
         "us.gal" => ordinary("gallon", "US gal", "Volume", "🧪"),
-        "pt" => ordinary("imperial_pint", "imp pt", "Volume", "🧪"),
+        "pt" => match customary_system {
+            CustomarySystem::Imperial => ordinary("imperial_pint", "imp pt", "Volume", "🧪"),
+            CustomarySystem::UsCustomary => ordinary("pint", "US pt", "Volume", "🧪"),
+        },
         "us.pt" => ordinary("pint", "US pt", "Volume", "🧪"),
         "ml" => ordinary("mL", "ml", "Volume", "🧪"),
-        "tbsp." => ordinary("tablespoon", "tbsp.", "Volume", "🧪"),
+        "tbsp." => match customary_system {
+            CustomarySystem::Imperial => ordinary("imperial_tablespoon", "tbsp.", "Volume", "🧪"),
+            CustomarySystem::UsCustomary => ordinary("tablespoon", "tbsp.", "Volume", "🧪"),
+        },
         "cup" => ordinary("cup", "cup", "Volume", "🧪"),
         "cm3" => ordinary("cm^3", "cm³", "Volume", "🧪"),
         "ft3" => ordinary("ft^3", "ft³", "Volume", "🧪"),
         "in3" => ordinary("in^3", "in³", "Volume", "🧪"),
         "mm3" => ordinary("mm^3", "mm³", "Volume", "🧪"),
-        "fl.oz" | "floz" => ordinary("imperial_fluidounce", "imp fl oz", "Volume", "🧪"),
+        "fl.oz" | "floz" => match customary_system {
+            CustomarySystem::Imperial => {
+                ordinary("imperial_fluidounce", "imp fl oz", "Volume", "🧪")
+            }
+            CustomarySystem::UsCustomary => ordinary("fluidounce", "US fl oz", "Volume", "🧪"),
+        },
         "us.fl.oz" | "us.floz" => ordinary("fluidounce", "US fl oz", "Volume", "🧪"),
         "US. liq. gi" => ordinary("gallon / 32", "US. liq. gi", "Volume", "🧪"),
         "US. liq. qt" => ordinary("gallon / 4", "US. liq. qt", "Volume", "🧪"),
@@ -280,7 +337,10 @@ pub fn legacy_unit(alias: &str) -> Option<LegacyUnit> {
         "µl" => ordinary("microliter", "µl", "Volume", "🧪"),
         "dl" => ordinary("deciliter", "dl", "Volume", "🧪"),
         "cl" => ordinary("centiliter", "cl", "Volume", "🧪"),
-        "tsp." => ordinary("legacy_metric_teaspoon", "tsp.", "Volume", "🧪"),
+        "tsp." => match customary_system {
+            CustomarySystem::Imperial => ordinary("imperial_teaspoon", "tsp.", "Volume", "🧪"),
+            CustomarySystem::UsCustomary => ordinary("teaspoon", "tsp.", "Volume", "🧪"),
+        },
         _ => return None,
     })
 }


### PR DESCRIPTION
This pull request introduces explicit support for UK/US customary unit aliases and adds a user preference for ambiguous legacy unit shorthand, allowing users to select either Imperial (UK) or US customary definitions for units like `gal`, `pt`, `fl.oz`, etc. It updates the configuration UI, documentation, and core logic to support this preference, and includes comprehensive tests to ensure correct behavior.

**Feature additions:**

* Added explicit UK/US customary aliases for cross-system unit conversions, including short and long forms such as `uk_gal`, `us_fluid_ounce`, etc. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46-R51) [[3]](diffhunk://#diff-ef6dac0c1c122a5c9efd56197356cab3608e10a0ff362195e31e0bda9d4a1e7eL339-R341)
* Introduced a user-selectable preference for ambiguous legacy unit shorthand, defaulting to Imperial (UK) but allowing US customary as an option. This is reflected in the configuration UI (`info.plist`) and handled in workflow settings. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R5) [[2]](diffhunk://#diff-ef6dac0c1c122a5c9efd56197356cab3608e10a0ff362195e31e0bda9d4a1e7eR531-R556) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR192) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR220-R228)

**Core logic and API changes:**

* Refactored conversion logic to use the new `CustomarySystem` enum, with functions like `conversion_item_with_customary_system` and `legacy_conversion_with_customary_system` to respect the user’s preference throughout the codebase. [[1]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L14-R16) [[2]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R97-R122) [[3]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L115-R143) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL9-R16) [[5]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL110-R115)

**Documentation updates:**

* Updated `README.md`, `CHANGELOG.md`, and `info.plist` to document the new aliases, the default customary units preference, and examples of explicit cross-system conversions. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46-R51) [[3]](diffhunk://#diff-ef6dac0c1c122a5c9efd56197356cab3608e10a0ff362195e31e0bda9d4a1e7eL339-R341) [[4]](diffhunk://#diff-ef6dac0c1c122a5c9efd56197356cab3608e10a0ff362195e31e0bda9d4a1e7eR531-R556)

**Testing:**

* Added and updated tests to verify correct behavior for both default and explicit customary system settings, including fallback and error cases. [[1]](diffhunk://#diff-c0caf37435bdc3f34b7a9fad14e41af39ceec31e7656041d34158de894a19f40L2-R6) [[2]](diffhunk://#diff-c0caf37435bdc3f34b7a9fad14e41af39ceec31e7656041d34158de894a19f40R452-R592) [[3]](diffhunk://#diff-0033c8748526498719d37e931988fd4e20a219ad6669f5938afd9792d69f0e3aR4) [[4]](diffhunk://#diff-0033c8748526498719d37e931988fd4e20a219ad6669f5938afd9792d69f0e3aR127-R141) [[5]](diffhunk://#diff-0033c8748526498719d37e931988fd4e20a219ad6669f5938afd9792d69f0e3aR172-R178) [[6]](diffhunk://#diff-0033c8748526498719d37e931988fd4e20a219ad6669f5938afd9792d69f0e3aR195-R238) [[7]](diffhunk://#diff-c781b6e0d27baf354ca6765fba2efd4a4d5beb60d8051e39a0a6f941fc50612fL1-R5)

**Versioning:**

* Bumped the package version to `1.3.1` to reflect these new features.