### PR TITLE
chore: remove discontinued RUB currency references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.2
+
+- [FIX] remove the discontinued ECB EUR/RUB reference rate from the currency catalogue
+
 ## 1.3.1
 
 - [FEAT] add explicit UK/US customary aliases for cross-system unit conversions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "alfred_convert"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "alfred_workflow_rs",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alfred_convert"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Convert currencies and physical units with Alfred."

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In order to set a default currency, you can set it in the Workflow Configuration
 
 ![default_currency](default_currency.png)
 
-Valid values are the [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency codes: AUD, BRL, CAD, CHF, CNY, CZK, DKK, EUR, GBP, HKD, HUF, IDR, ILS, INR, ISK, JPY, KRW, MXN, MYR, NOK, NZD, PHP, PLN, RON, RUB, SEK, SGD, THB, TRY, USD, ZAR.
+Valid values are the [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency codes currently published by the ECB: AUD, BRL, CAD, CHF, CNY, CZK, DKK, EUR, GBP, HKD, HUF, IDR, ILS, INR, ISK, JPY, KRW, MXN, MYR, NOK, NZD, PHP, PLN, RON, SEK, SGD, THB, TRY, USD, ZAR.
 
 ### Default customary units
 

--- a/info.plist
+++ b/info.plist
@@ -490,10 +490,6 @@ The Default customary units preference selects Imperial (UK) or US customary def
 						<string>RON</string>
 					</array>
 					<array>
-						<string>Russian rouble (RUB)</string>
-						<string>RUB</string>
-					</array>
-					<array>
 						<string>Swedish krona (SEK)</string>
 						<string>SEK</string>
 					</array>

--- a/src/currency/catalog.rs
+++ b/src/currency/catalog.rs
@@ -41,8 +41,8 @@ impl Currency {
     }
 }
 
-/// Currencies retained in the Dart workflow's stable display order.
-pub const CURRENCIES: [Currency; 31] = [
+/// Currencies retained in the workflow's stable display order.
+pub const CURRENCIES: [Currency; 30] = [
     Currency::new("AUD", "Australian dollar", "🇦🇺"),
     Currency::new("BRL", "Brazilian real", "🇧🇷"),
     Currency::new("CAD", "Canadian dollar", "🇨🇦"),
@@ -67,7 +67,6 @@ pub const CURRENCIES: [Currency; 31] = [
     Currency::new("PHP", "Philippine peso", "🇵🇭"),
     Currency::new("PLN", "Polish zloty", "🇵🇱"),
     Currency::new("RON", "Romanian leu", "🇷🇴"),
-    Currency::new("RUB", "Russian rouble", "🇷🇺"),
     Currency::new("SEK", "Swedish krona", "🇸🇪"),
     Currency::new("SGD", "Singapore dollar", "🇸🇬"),
     Currency::new("THB", "Thai baht", "🇹🇭"),

--- a/src/tests/currency.rs
+++ b/src/tests/currency.rs
@@ -3,7 +3,13 @@ use std::collections::BTreeMap;
 use jiff::Timestamp;
 use rust_decimal::Decimal;
 
-use super::{Currency, ExchangeRates, divide_like_dart};
+use super::{CURRENCIES, Currency, ExchangeRates, divide_like_dart};
+
+#[test]
+fn discontinued_russian_rouble_should_not_be_supported() {
+    assert!(Currency::from_code("RUB").is_none());
+    assert!(CURRENCIES.iter().all(|currency| currency.code() != "RUB"));
+}
 
 #[test]
 fn divide_should_keep_finite_precision_and_truncate_repeating_values() -> anyhow::Result<()> {

--- a/src/tests/ecb.rs
+++ b/src/tests/ecb.rs
@@ -76,6 +76,18 @@ fn successful_response_should_parse_supported_rates_and_cache_them() -> anyhow::
 }
 
 #[test]
+fn discontinued_russian_rouble_should_be_ignored_in_ecb_xml() -> anyhow::Result<()> {
+    let xml = r#"<?xml version="1.0"?><Envelope><Cube><Cube time="2026-08-21"><Cube currency="RUB" rate="94.1234"/><Cube currency="USD" rate="1.1732"/></Cube></Cube></Envelope>"#;
+    let rates = parse_exchange_rates(xml, None, "2026-08-21T17:00:00Z".parse()?)?;
+    assert_eq!(rates.rates.get("RUB"), None);
+    assert_eq!(
+        rates.rates.get("USD"),
+        Some(&rust_decimal::Decimal::new(11_732, 4))
+    );
+    Ok(())
+}
+
+#[test]
 fn xml_source_date_should_remain_on_the_same_utc_day() -> anyhow::Result<()> {
     let xml = r#"<?xml version="1.0"?><Envelope><Cube><Cube time="2026-08-21"><Cube currency="USD" rate="1.1732"/></Cube></Cube></Envelope>"#;
     let now = "2026-08-21T17:00:00Z".parse::<Timestamp>()?;

--- a/src/tests/main.rs
+++ b/src/tests/main.rs
@@ -145,6 +145,15 @@ fn workflow_settings_should_load_all_select_preferences() -> anyhow::Result<()> 
 }
 
 #[test]
+fn workflow_settings_should_fall_back_when_rub_is_saved_as_default_currency() -> anyhow::Result<()>
+{
+    let defaults = BTreeMap::from([select_configuration("default_currency", "RUB")]);
+    let settings = workflow_settings_from_defaults(&defaults)?;
+    assert_eq!(settings.home_currency.code(), "USD");
+    Ok(())
+}
+
+#[test]
 fn workflow_settings_should_fall_back_for_wrong_action_configuration_type() -> anyhow::Result<()> {
     let defaults = BTreeMap::from([
         select_configuration("default_currency", "USD"),


### PR DESCRIPTION
This pull request removes support for the discontinued ECB EUR/RUB (Russian rouble) reference rate across the codebase, documentation, and tests. The main goal is to ensure the workflow no longer recognizes or displays RUB as a supported currency, aligning with the latest ECB published rates.

**Currency support removal:**
* [`src/currency/catalog.rs`](diffhunk://#diff-f18216465a29f799ef20ae629b5380f01a57fa7d8a7dd3516b71197ae269c443L44-R45): Removed `RUB` from the `CURRENCIES` array and its definition, reducing the count from 31 to 30. [[1]](diffhunk://#diff-f18216465a29f799ef20ae629b5380f01a57fa7d8a7dd3516b71197ae269c443L44-R45) [[2]](diffhunk://#diff-f18216465a29f799ef20ae629b5380f01a57fa7d8a7dd3516b71197ae269c443L70)
* [`info.plist`](diffhunk://#diff-ef6dac0c1c122a5c9efd56197356cab3608e10a0ff362195e31e0bda9d4a1e7eL492-L495): Removed the Russian rouble (RUB) entry from the currency selection options.

**Documentation updates:**
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R42): Updated the list of valid ISO 4217 currency codes to remove RUB and clarify that only currently published ECB currencies are supported.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R4): Added a changelog entry for version 1.3.2 documenting the removal of RUB.
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3): Bumped version to 1.3.2.

**Test coverage:**
* [`src/tests/currency.rs`](diffhunk://#diff-72244a6d097f4155f3280623b9dad4850ae4affaf0affdc04149218ec7842287L6-R12): Added a test to confirm that RUB is not supported or present in the currency list.
* [`src/tests/ecb.rs`](diffhunk://#diff-55d6c7b253d3fda00759eaec59db77b482fc3d34730bd811313107be55f6e88cR78-R89): Added a test to ensure that RUB rates in ECB XML are ignored and not parsed.
* [`src/tests/main.rs`](diffhunk://#diff-0033c8748526498719d37e931988fd4e20a219ad6669f5938afd9792d69f0e3aR147-R155): Added a test to verify that if RUB is saved as the default currency, the workflow falls back to USD.